### PR TITLE
thlack.surfs/render now handles nested sequences

### DIFF
--- a/src/thlack/surfs.clj
+++ b/src/thlack/surfs.clj
@@ -1,7 +1,8 @@
 (ns thlack.surfs
   "A hiccup-like interface for creating views in Slack applications via blocks.
    https://api.slack.com/reference/block-kit/blocks"
-  (:require [thlack.surfs.render :as surfs.render]))
+  (:require [thlack.surfs.render :as surfs.render]
+            [thlack.surfs.props :as props]))
 
 (defn render
   "Render one or more surfs components into a data structure
@@ -40,12 +41,14 @@
   ```
   Note: The returned data structure must be serialized to json (not included) before being sent to Slack."
   [& components]
-  (map surfs.render/render components))
+  (->> components
+       (map surfs.render/render)
+       (props/flatten-children)))
 
 (defn- build-defc-body
   [[bindings & body]]
   `(~bindings
-    (first (thlack.surfs/render ~@body))))
+    (thlack.surfs/render ~@body)))
 
 (defn- defc'
   "Helper for generating the body of defc"

--- a/src/thlack/surfs/messages/components/spec.clj
+++ b/src/thlack/surfs/messages/components/spec.clj
@@ -9,7 +9,7 @@
 (s/def :message/props
   (s/keys :opt-un [:message/thread_ts :message/mrkdwn]))
 
-(s/def :message/child (s/or :block ::blocks.spec/block))
+(s/def :message/child (s/or :block ::blocks.spec/block :text :message/text))
 
 (s/def :message/children
   (s/with-gen

--- a/test/thlack/surfs/examples_test.clj
+++ b/test/thlack/surfs/examples_test.clj
@@ -2,6 +2,7 @@
   "Way less cool unit test suite, but it's useful for seeing surfs
    in action :)"
   (:require [clojure.test :refer [is]]
+            [thlack.surfs :refer [defc]]
             [thlack.surfs.test-utils :refer [defrendertest]]))
 
 ;;; Composition
@@ -874,3 +875,24 @@
                                     :text "Click Me!"}}
             :text      {:type :plain_text
                         :text "Hello"}} element))))
+
+;;; Misc
+
+(defn render-sibling
+  [n]
+  [:divider {:block_id (str "sibling_" n)}])
+
+(defc super-interesting-component
+  [siblings]
+  [:header "Header"]
+  (map render-sibling siblings))
+
+(defrendertest block-with-sequence-of-siblings
+  [super-interesting-component [1 2]]
+  (fn [[blocks]]
+    (let [expected [{:type :header
+                     :text {:type :plain_text
+                            :text "Header"}}
+                    {:type :divider :block_id "sibling_1"}
+                    {:type :divider :block_id "sibling_2"}]]
+      (is (= blocks expected)))))


### PR DESCRIPTION
closes #5 

The settled upon solution:

* Render supports nested sequences the same way all components do - via `props/flatten-children`
* `defc` removes the explicit call to `first` and now allows multiple elements to be rendered.