### PR TITLE
Remove expound

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Slack's [Block Kit](https://api.slack.com/block-kit) is great! Writing blocks as
 * Familiar - Like [hiccup](https://github.com/weavejester/hiccup), [reagent](https://github.com/reagent-project/reagent), and [rum](https://github.com/tons)
 * Spec driven
     * There are specs for the whole block kit!
-    * Detailed validation messages given via [expound](https://github.com/bhb/expound)
+    * All component functions have specs via `(s/fdef)`
+    * All results are run through `(s/assert)` 
     * Learn about components through their specs!
 * Easier than writing hash maps
 * Easier to create reusable templates
@@ -36,6 +37,14 @@ Slack's [Block Kit](https://api.slack.com/block-kit) is great! Writing blocks as
 
 Surfs renders Slack blocks, elements, and composition objects from vectors. It also
 supports defining and using custom components (to organize and encapsulate Slack elements).
+
+### Development
+
+Surfs uses [clojure.spec.alpha/assert](https://clojuredocs.org/clojure.spec.alpha/assert) on all rendered results. All component functions contain function specs. This can greatly improve the development experience at the repl.
+
+See:
+* [clojure.spec.alpha/check-asserts](https://clojuredocs.org/clojure.spec.alpha/check-asserts)
+* [clojure.spec.test.alpha/instrument](https://clojure.github.io/spec.alpha/clojure.spec.test.alpha-api.html#clojure.spec.test.alpha/instrument)
 
 ### Rendering components
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,10 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        expound/expound     {:mvn/version "0.8.6"}}
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.0.0"}
-                      metosin/jsonista       {:mvn/version "0.2.7"}}}
+                      metosin/jsonista       {:mvn/version "0.2.7"}
+                      expound/expound        {:mvn/version "0.8.6"}}}
   
   :runner
   {:extra-deps {com.cognitect/test-runner

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,6 @@
       <artifactId>clojure</artifactId>
       <version>1.10.1</version>
     </dependency>
-    <dependency>
-      <groupId>expound</groupId>
-      <artifactId>expound</artifactId>
-      <version>0.8.6</version>
-    </dependency>
   </dependencies>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/src/thlack/surfs/elements/components/spec.clj
+++ b/src/thlack/surfs/elements/components/spec.clj
@@ -71,7 +71,7 @@
   (gen/fmap
    (fn [select]
      (-> select
-         (select-keys [:options :option-groups])
+         (select-keys [:options :option_groups])
          (vals)
          (flatten)
          (into

--- a/src/thlack/surfs/props.clj
+++ b/src/thlack/surfs/props.clj
@@ -1,6 +1,5 @@
 (ns ^:no-doc thlack.surfs.props
   (:require [clojure.spec.alpha :as s]
-            [expound.alpha :as expound]
             [thlack.surfs.blocks.spec]))
 
 ;;; Prop helpers
@@ -36,8 +35,9 @@
   [x spec]
   `(let [conformed# (s/conform ~spec ~x)]
      (if (s/invalid? conformed#)
-       (throw (ex-info (expound/expound-str ~spec ~x)
-                       (or (s/explain ~spec ~x) {:explained? false})))
+       (do
+         (s/assert ~spec ~x)
+         nil)
        conformed#)))
 
 (defn- detag

--- a/src/thlack/surfs/validation.clj
+++ b/src/thlack/surfs/validation.clj
@@ -1,14 +1,9 @@
 (ns ^:no-doc thlack.surfs.validation
   "Handles validation for components"
-  (:require [clojure.spec.alpha :as s]
-            [expound.alpha :as expound]))
+  (:require [clojure.spec.alpha :as s]))
 
 (defmacro validated
   "Returns a data structure that is validated against a spec or throws an informative
    exception."
   [x spec]
-  `(if (s/valid? ~spec ~x)
-     ~x
-     (let [explain-data# (s/explain-data ~spec ~x)]
-       (throw (ex-info (expound/expound-str ~spec ~x)
-                       explain-data#)))))
+  `(s/assert ~spec ~x))

--- a/test/thlack/surfs/render_test.clj
+++ b/test/thlack/surfs/render_test.clj
@@ -14,15 +14,11 @@
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.messages.components.spec]
             [thlack.surfs.messages.spec :as messages.spec]
+            [thlack.surfs.test-utils :refer [render]]
             [thlack.surfs.views.components.spec]
             [thlack.surfs.views.spec :as views.spec]))
 
 (def iterations 10)
-
-(defmacro render
-  [spec component]
-  `(let [result# (surfs.render/render ~component)]
-     (is (true? (s/valid? ~spec result#)))))
 
 ;;; Composition elements
 

--- a/test/thlack/surfs/test_utils.clj
+++ b/test/thlack/surfs/test_utils.clj
@@ -7,6 +7,8 @@
 
 (set! s/*explain-out* expound/printer)
 
+(s/check-asserts true)
+
 (defn check
   [sym num-tests]
   (let [check-result (st/check sym {:clojure.spec.test.check/opts {:num-tests num-tests}})
@@ -29,3 +31,8 @@
         assert-fn  (last children)]
     `(deftest ~name
        (~assert-fn (apply surfs/render ~components)))))
+
+(defmacro render
+  [spec component]
+  `(let [result# (surfs.render/render ~component)]
+     (is (true? (s/valid? ~spec result#)))))


### PR DESCRIPTION
Closes #4 

Removes expound as a dependency of the surfs lib.

It is still used in the test suite, but is no longer required for user land consumption. 

Adds some documentation on how to best leverage this. 

Also fixes some random failures in select tests due to a faulty generator. 