### PR TITLE
Chore/namespaced keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ See:
 * [clojure.spec.alpha/check-asserts](https://clojuredocs.org/clojure.spec.alpha/check-asserts)
 * [clojure.spec.test.alpha/instrument](https://clojure.github.io/spec.alpha/clojure.spec.test.alpha-api.html#clojure.spec.test.alpha/instrument)
 
+#### repl uilities
+
+The `thlack.surfs.repl` namespace contains some useful utilities for developing with Surfs.
+
+* `(describe :tag)`
+  Get render function metadata and `fspec`.
+* `(doc :tag)`
+  Print component signatures, docstrings, and examples right to the repl!
+* `(props :tag)`
+  Get the prop spec for a component (if it has one).
+
 ### Rendering components
 
 The heart of Surfs is the `render` function.

--- a/doc/components.md
+++ b/doc/components.md
@@ -63,7 +63,7 @@ Renders to a [text object](https://api.slack.com/reference/block-kit/composition
 **Props**:
 
 ```clojure
-(s/describe :thlack.surfs.props.spec/text)
+(thlack.surfs.repl/props :text)
 ```
 
 **Usage**:
@@ -162,7 +162,7 @@ Renders a [confirmation dialog object](https://api.slack.com/reference/block-kit
 **Props**:
 
 ```clojure
-(s/describe :confirm/props)
+(thlack.surfs.repl/props :confirm)
 ```
 
 **Children**:
@@ -198,7 +198,7 @@ Renders an [option object](https://api.slack.com/reference/block-kit/composition
 **Props**
 
 ```clojure
-(s/describe :option/props)
+(thlack.surfs.repl/props :option)
 ```
 
 **Children**
@@ -257,7 +257,7 @@ Renders a [button element](https://api.slack.com/reference/block-kit/block-eleme
 **Props**:
 
 ```clojure
-(s/describe :button/props)
+(thlack.surfs.repl/props :button)
 ```
 
 The `:button` component can safely omit the `:action_id` prop (and thus all props). If `:action_id` is not provided, a uuid string will be generated. This simplifies cases where the button action_id may be ignored - as is the case with buttons that are used for opening urls.
@@ -317,7 +317,7 @@ Renders a [checkbox group](https://api.slack.com/reference/block-kit/block-eleme
 **Props**
 
 ```clojure
-(s/describe :checkboxes/props)
+(thlack.surfs.repl/props :checkboxes)
 ```
 
 **Children**
@@ -372,7 +372,7 @@ Renders a [date picker element](https://api.slack.com/reference/block-kit/block-
 **Props**
 
 ```clojure
-(s/describe :datepicker/props)
+(thlack.surfs.repl/props :datepicker)
 ```
 
 **Children**
@@ -421,7 +421,7 @@ Renders an [image element](https://api.slack.com/reference/block-kit/block-eleme
 **Props**
 
 ```clojure
-(s/describe :img/props)
+(thlack.surfs.repl/props :img)
 ```
 
 **Usage**
@@ -441,8 +441,7 @@ Renders a [static multi select element](https://api.slack.com/reference/block-ki
 **Props**
 
 ```clojure
-(s/describe :multi-select/props)
-```
+(thlack.surfs.repl/props :multi-static-select)
 
 **Children**
 
@@ -539,7 +538,7 @@ Renders an [external multi select element](https://api.slack.com/reference/block
 **Props**
 
 ```clojure
-(s/describe :multi-external-select/props)
+(thlack.surfs.repl/props :multi-external-select)
 ```
 
 **Children**
@@ -601,7 +600,7 @@ Renders a [users multi select element](https://api.slack.com/reference/block-kit
 **Props**
 
 ```clojure
-(s/describe :multi-users-select/props)
+(thlack.surfs.repl/props :multi-users-select)
 ```
 
 **Children**
@@ -652,7 +651,7 @@ Renders a [conversation multi select element](https://api.slack.com/reference/bl
 **Props**
 
 ```clojure
-(s/describe :multi-conversations-select/props)
+(thlack.surfs.repl/props :multi-conversations-select)
 ```
 
 **Children**
@@ -719,7 +718,7 @@ Renders a [channel multi select element](https://api.slack.com/reference/block-k
 **Props**
 
 ```clojure
-(s/describe :multi-channels-select/props)
+(thlack.surfs.repl/props :multi-channels-select)
 ```
 
 **Children**
@@ -770,7 +769,7 @@ Renders an [overflow menu element](https://api.slack.com/reference/block-kit/blo
 **Props**
 
 ```clojure
-(s/describe :overflow/props)
+(thlack.surfs.repl/props :overflow)
 ```
 
 The `:overflow` component can safely omit the `:action_id` prop (and thus all props). If `:action_id` is not provided, a uuid string will be generated. This simplifies cases where the overflow action_id may be ignored - as is the case with overflow menus containing only urls.
@@ -843,7 +842,7 @@ Renders a [plain-text input element](https://api.slack.com/reference/block-kit/b
 **Props**
 
 ```clojure
-(s/describe :plain-text-input/props)
+(thlack.surfs.repl/props :plain-text-input)
 ```
 
 **Children**
@@ -882,7 +881,7 @@ Renders a [radio button group element](https://api.slack.com/reference/block-kit
 **Props**
 
 ```clojure
-(s/describe :radio-buttons/props)
+(thlack.surfs.repl/props :radio-buttons)
 ```
 
 **Children**
@@ -941,7 +940,7 @@ Renders a [static select element](https://api.slack.com/reference/block-kit/bloc
 **Props**
 
 ```clojure
-(s/describe :static-select/props)
+(thlack.surfs.repl/props :static-select)
 ```
 
 **Children**
@@ -1036,7 +1035,7 @@ Renders an [external select element](https://api.slack.com/reference/block-kit/b
 **Props**
 
 ```clojure
-(s/describe :external-select/props)
+(thlack.surfs.repl/props :external-select)
 ```
 
 **Children**
@@ -1092,7 +1091,7 @@ Renders a [users select element](https://api.slack.com/reference/block-kit/block
 **Props**
 
 ```clojure
-(s/describe :users-select/props)
+(thlack.surfs.repl/props :users-select)
 ```
 
 **Children**
@@ -1141,7 +1140,7 @@ Renders a [conversation select element](https://api.slack.com/reference/block-ki
 **Props**
 
 ```clojure
-(s/describe :conversations-select/props)
+(thlack.surfs.repl/props :conversations-select)
 ```
 
 **Children**
@@ -1204,7 +1203,7 @@ Renders a [channel select element](https://api.slack.com/reference/block-kit/blo
 **Props**
 
 ```clojure
-(s/describe :channels-select/props)
+(thlack.surfs.repl/props :channels-select)
 ```
 
 **Children**
@@ -1253,7 +1252,7 @@ Renders a [time picker element](https://api.slack.com/reference/block-kit/block-
 **Props**
 
 ```clojure
-(s/describe :timepicker/props)
+(thlack.surfs.repl/props :timepicker)
 ```
 
 **Children**
@@ -1306,7 +1305,7 @@ Renders an [actions block](https://api.slack.com/reference/block-kit/blocks#acti
 **Props**
 
 ```clojure
-(s/describe :block/props)
+(thlack.surfs.repl/props :actions)
 ```
 
 Props for `:actions` are optional.
@@ -1377,7 +1376,7 @@ Renders a [context block](https://api.slack.com/reference/block-kit/blocks#conte
 **Props**
 
 ```clojure
-(s/describe :block/props)
+(thlack.surfs.repl/props :context)
 ```
 
 Props for `:context` are optional.
@@ -1422,7 +1421,7 @@ Renders a [divider block](https://api.slack.com/reference/block-kit/blocks#divid
 **Props**
 
 ```clojure
-(s/describe :block/props)
+(thlack.surfs.repl/props :divider)
 ```
 
 Props for `:divider` are optional.
@@ -1444,7 +1443,7 @@ Renders a [header block](https://api.slack.com/reference/block-kit/blocks#header
 **Props**
 
 ```clojure
-(s/describe :block/props)
+(thlack.surfs.repl/props :header)
 ```
 
 Props for `:header` are optional.
@@ -1478,7 +1477,7 @@ Renders an [image block](https://api.slack.com/reference/block-kit/blocks#image)
 **Props**
 
 ```clojure
-(s/describe :image/props)
+(thlack.surfs.repl/props :image)
 ```
 
 **Children**
@@ -1511,7 +1510,7 @@ Renders an [input block](https://api.slack.com/reference/block-kit/blocks#input)
 **Props**
 
 ```clojure
-(s/describe :input/props)
+(thlack.surfs.repl/props :input)
 ```
 
 Props for `:input` are optional.
@@ -1576,7 +1575,7 @@ Renders a [section block](https://api.slack.com/reference/block-kit/blocks#secti
 **Props**
 
 ```clojure
-(s/describe :block/props)
+(thlack.surfs.repl/props :section)
 ```
 
 Props for `:section` are optional.
@@ -1693,7 +1692,7 @@ Renders a [modal surface](https://api.slack.com/surfaces/modals/using).
 **Props**
 
 ```clojure
-(s/describe :modal/props)
+(thlack.surfs.repl/props :modal)
 ```
 
 **Children**
@@ -1730,7 +1729,7 @@ Renders a [home tab surface](https://api.slack.com/surfaces/tabs/using).
 **Props**
 
 ```clojure
-(s/describe :view/props)
+(thlack.surfs.repl/props :home)
 ```
 
 **Children**
@@ -1762,7 +1761,7 @@ blocks | * (requires at least one block) | One or more of [actions](#actions), [
 **Props**
 
 ```clojure
-(s/describe :message/props)
+(thlack.surfs.repl/props :message)
 ```
 
 * Note: Since the message component renders to a flat structure, additional props can be included (this should simplify using messages in their various contexts).

--- a/src/thlack/surfs/blocks/components.clj
+++ b/src/thlack/surfs/blocks/components.clj
@@ -3,6 +3,7 @@
    https://api.slack.com/reference/block-kit/blocks"
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.blocks.spec :as blocks.spec]
+            [thlack.surfs.blocks.spec.section :as section.spec]
             [thlack.surfs.blocks.components.spec :as bc.spec]
             [thlack.surfs.composition.components :as comp]
             [thlack.surfs.composition.spec :as comp.spec]
@@ -37,14 +38,14 @@
      [:placeholder \"Select channel\"]]]
    ```"
   [& args]
-  (let [[props & children] (props/parse-args args :block/props*)]
+  (let [[props & children] (props/parse-args args ::bc.spec/block.props*)]
     (-> props
         (assoc :elements (props/flatten-children children) :type :actions)
         (validated ::blocks.spec/actions))))
 
 (s/fdef actions
-  :args (s/alt :props-and-children (s/cat :props :block/props :children :actions/children)
-               :children (s/cat :children :actions/children))
+  :args (s/alt :props-and-children (s/cat :props ::bc.spec/block.props :children ::bc.spec/actions.children)
+               :children (s/cat :children ::bc.spec/actions.children))
   :ret ::blocks.spec/actions)
 
 (defn fields
@@ -73,7 +74,7 @@
   (if-not (some? x)
     props
     (let [child   (if (and (seq x) (not (map? x))) (first x) x)
-          [tag _] (s/conform :section/child child)]
+          [tag _] (s/conform ::bc.spec/section.child child)]
       (cond-> props
         (= :text tag) (assoc :text child)
         (= :accessory tag) (assoc :accessory child)
@@ -110,51 +111,51 @@
       [:text \"This is irreversible!\"]]]]
    ```"
   [& args]
-  (let [[props & children] (props/parse-args args :block/props*)]
+  (let [[props & children] (props/parse-args args ::bc.spec/block.props*)]
     (reduce with-section-child (assoc props :type :section) children)))
 
 (s/fdef section
-  :args (s/alt :props-and-text   (s/cat :props :block/props
-                                        :text :section/text)
-               :props-and-fields (s/cat :props :block/props
+  :args (s/alt :props-and-text   (s/cat :props ::bc.spec/block.props
+                                        :text ::section.spec/text)
+               :props-and-fields (s/cat :props ::bc.spec/block.props
                                         :fields ::blocks.spec/fields)
-               :props-and-text-and-accessory (s/cat :props :block/props
-                                                    :text :section/text
-                                                    :accessory :section/accessory)
-               :props-and-accessory-and-text (s/cat :props :block/props
-                                                    :accessory :section/accessory
-                                                    :text :section/text)
-               :props-and-fields-and-accessory (s/cat :props :block/props
+               :props-and-text-and-accessory (s/cat :props ::bc.spec/block.props
+                                                    :text ::section.spec/text
+                                                    :accessory ::section.spec/accessory)
+               :props-and-accessory-and-text (s/cat :props ::bc.spec/block.props
+                                                    :accessory ::section.spec/accessory
+                                                    :text ::section.spec/text)
+               :props-and-fields-and-accessory (s/cat :props ::bc.spec/block.props
                                                       :fields ::blocks.spec/fields
-                                                      :accessory :section/accessory)
-               :props-and-accessory-and-fields (s/cat :props :block/props
-                                                      :accessory :section/accessory
+                                                      :accessory ::section.spec/accessory)
+               :props-and-accessory-and-fields (s/cat :props ::bc.spec/block.props
+                                                      :accessory ::section.spec/accessory
                                                       :fields ::blocks.spec/fields)
-               :props-and-text-and-fields (s/cat :props :block/props
-                                                 :text :section/text
+               :props-and-text-and-fields (s/cat :props ::bc.spec/block.props
+                                                 :text ::section.spec/text
                                                  :fields ::blocks.spec/fields)
-               :props-and-fields-and-text (s/cat :props :block/props
+               :props-and-fields-and-text (s/cat :props ::bc.spec/block.props
                                                  :fields ::blocks.spec/fields
-                                                 :text :section/text)
+                                                 :text ::section.spec/text)
 
-               :text   (s/cat :text :section/text)
+               :text   (s/cat :text ::section.spec/text)
                :fields (s/cat :fields ::blocks.spec/fields)
-               :text-and-accessory (s/cat :text :section/text
-                                          :accessory :section/accessory)
-               :accessory-and-text (s/cat :accessory :section/accessory
-                                          :text :section/text)
+               :text-and-accessory (s/cat :text ::section.spec/text
+                                          :accessory ::section.spec/accessory)
+               :accessory-and-text (s/cat :accessory ::section.spec/accessory
+                                          :text ::section.spec/text)
                :fields-and-accessory (s/cat :fields ::blocks.spec/fields
-                                            :accessory :section/accessory)
-               :accessory-and-fields (s/cat :accessory :section/accessory
+                                            :accessory ::section.spec/accessory)
+               :accessory-and-fields (s/cat :accessory ::section.spec/accessory
                                             :fields ::blocks.spec/fields)
-               :text-and-fields (s/cat :text :section/text
+               :text-and-fields (s/cat :text ::section.spec/text
                                        :fields ::blocks.spec/fields)
                :fields-and-text (s/cat :fields ::blocks.spec/fields
-                                       :text :section/text)
-               :all (s/cat :props :block/props
-                           :text :section/text
+                                       :text ::section.spec/text)
+               :all (s/cat :props ::bc.spec/block.props
+                           :text ::section.spec/text
                            :fields ::blocks.spec/fields
-                           :accessory :section/accessory))
+                           :accessory ::section.spec/accessory))
   :ret ::blocks.spec/section)
 
 (defn context
@@ -176,14 +177,14 @@
     [:text \"This is some text\"]]
    ```"
   [& args]
-  (let [[props & children] (props/parse-args args :block/props*)]
+  (let [[props & children] (props/parse-args args ::bc.spec/block.props*)]
     (-> props
         (assoc :elements (props/flatten-children children) :type :context)
         (validated ::blocks.spec/context))))
 
 (s/fdef context
-  :args (s/alt :props-and-children (s/cat :props :block/props :children :context/children)
-               :children (s/cat :children :context/children))
+  :args (s/alt :props-and-children (s/cat :props ::bc.spec/block.props :children ::bc.spec/context.children)
+               :children (s/cat :children ::bc.spec/context.children))
   :ret ::blocks.spec/context)
 
 (defn divider
@@ -200,7 +201,7 @@
    (divider {})))
 
 (s/fdef divider
-  :args (s/cat :props (s/? :block/props))
+  :args (s/cat :props (s/? ::bc.spec/block.props))
   :ret ::blocks.spec/divider)
 
 (defn header
@@ -226,8 +227,8 @@
    (header {} text)))
 
 (s/fdef header
-  :args (s/alt :props-and-children (s/cat :props :block/props :text :header-child/text)
-               :children (s/cat :text :header-child/text))
+  :args (s/alt :props-and-children (s/cat :props ::bc.spec/block.props :text :thlack.surfs.blocks.components.spec.header-child/text)
+               :children (s/cat :text :thlack.surfs.blocks.components.spec.header-child/text))
   :ret  ::blocks.spec/header)
 
 (defn image
@@ -251,7 +252,7 @@
    (image props nil)))
 
 (s/fdef image
-  :args (s/cat :props :image/props :title (s/? :image-child/title))
+  :args (s/cat :props ::bc.spec/image.props :title (s/? :thlack.surfs.blocks.components.spec.image-child/title))
   :ret ::blocks.spec/image)
 
 (defn input
@@ -284,10 +285,10 @@
   (let [[props label & children] (props/parse-args args bc.spec/input-props?)]
     (-> (assoc props :type :input)
         (assoc :label (comp/text label))
-        (props/with-children children :input/child)
+        (props/with-children children ::bc.spec/input.child)
         (validated ::blocks.spec/input))))
 
 (s/fdef input
-  :args (s/alt :props-and-children (s/cat :props :input/props :label :input-child/label :children :input/children)
-               :children (s/cat :label :input-child/label :children :input/children))
+  :args (s/alt :props-and-children (s/cat :props ::bc.spec/input.props :label :thlack.surfs.blocks.components.spec.input-child/label :children ::bc.spec/input.children)
+               :children (s/cat :label :thlack.surfs.blocks.components.spec.input-child/label :children ::bc.spec/input.children))
   :ret  ::blocks.spec/input)

--- a/src/thlack/surfs/blocks/components/spec.clj
+++ b/src/thlack/surfs/blocks/components/spec.clj
@@ -2,61 +2,67 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [thlack.surfs.blocks.spec :as blocks.spec]
+            [thlack.surfs.blocks.spec.actions :as actions]
+            [thlack.surfs.blocks.spec.context :as context]
+            [thlack.surfs.blocks.spec.header :as header]
+            [thlack.surfs.blocks.spec.image :as image]
+            [thlack.surfs.blocks.spec.input :as input]
+            [thlack.surfs.blocks.spec.section :as section]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
 
-(s/def :block/props (s/keys :opt-un [::strings.spec/block_id]))
+(s/def ::block.props (s/keys :opt-un [::strings.spec/block_id]))
 
 ; Internal use only - used for validating prop maps that MUST contain block_id in order to be considered props
-(s/def :block/props* (s/keys :req-un [::strings.spec/block_id]))
+(s/def ::block.props* (s/keys :req-un [::strings.spec/block_id]))
 
 ;;; [:actions]
 
-(s/def :actions/children
+(s/def ::actions.children
   (s/with-gen
-    (s/+ :actions/element)
-    #(s/gen :actions/elements)))
+    (s/+ ::actions/element)
+    #(s/gen ::actions/elements)))
 
 ;;; [:section]
 
-(s/def :section/child (s/or :text   :section/text
-                            :fields ::blocks.spec/fields
-                            :accessory :section/accessory))
+(s/def ::section.child (s/or :text   ::section/text
+                             :fields ::blocks.spec/fields
+                             :accessory ::section/accessory))
 
 ;;; [:context]
 
-(s/def :context/children
+(s/def ::context.children
   (s/with-gen
-    (s/+ :context/element)
-    #(s/gen :context/elements)))
+    (s/+ ::context/element)
+    #(s/gen ::context/elements)))
 
 ;;; [:header]
 
-(deftext :header-child/text (s/or :string ::strings.spec/string :text :header/text) 150)
+(deftext :thlack.surfs.blocks.components.spec.header-child/text (s/or :string ::strings.spec/string :text ::header/text) 150)
 
 ;;; [:image]
 
-(deftext :image-child/title (s/or :string ::strings.spec/string :text :image/title) 2000)
+(deftext :thlack.surfs.blocks.components.spec.image-child/title (s/or :string ::strings.spec/string :text ::image/title) 2000)
 
-(s/def :image/props (s/merge :block/props (s/keys :req-un [:image/image_url :image/alt_text])))
+(s/def ::image.props (s/merge ::block.props (s/keys :req-un [::image/image_url ::image/alt_text])))
 
 ;;; [:input]
 
-(deftext :input-child/label (s/or :string ::strings.spec/string :text :input/label) 2000)
+(deftext :thlack.surfs.blocks.components.spec.input-child/label (s/or :string ::strings.spec/string :text ::input/label) 2000)
 
-(s/def :input/child
+(s/def ::input.child
   (s/or :hint    ::comp.spec/plain-text
-        :element :input/element))
+        :element ::input/element))
 
-(s/def :input/children
+(s/def ::input.children
   (s/with-gen
-    (s/+ :input/child)
+    (s/+ ::input.child)
     #(gen/fmap
       (fn [input]
         (vals (select-keys input [:hint :element])))
       (s/gen ::blocks.spec/input))))
 
-(s/def :input/props (s/merge :block/props (s/keys :opt-un [:input/dispatch_action :input/optional])))
+(s/def ::input.props (s/merge ::block.props (s/keys :opt-un [::input/dispatch_action ::input/optional])))
 
 (defn input-props?
   "Predicate for seeing if the given props map constitutes input block props"

--- a/src/thlack/surfs/blocks/spec.clj
+++ b/src/thlack/surfs/blocks/spec.clj
@@ -1,131 +1,38 @@
 (ns ^:no-doc thlack.surfs.blocks.spec
   "https://api.slack.com/reference/block-kit/block-elements#checkboxes"
   (:require [clojure.spec.alpha :as s]
-            [thlack.surfs.composition.spec :as comp.spec]
-            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]
-            [thlack.surfs.elements.spec :as elements.spec]))
+            [thlack.surfs.blocks.spec.actions :as actions]
+            [thlack.surfs.blocks.spec.context :as context]
+            [thlack.surfs.blocks.spec.divider :as divider]
+            [thlack.surfs.blocks.spec.file :as file]
+            [thlack.surfs.blocks.spec.header :as header]
+            [thlack.surfs.blocks.spec.image :as image]
+            [thlack.surfs.blocks.spec.input :as input]
+            [thlack.surfs.blocks.spec.section :as section]
+            [thlack.surfs.strings.spec :as strings.spec]))
 
-(s/def :section/type #{:section})
-
-(deftext :section/text ::comp.spec/text 3000)
-
-(s/def :section/fields (s/coll-of (s/and ::comp.spec/text (strings.spec/max-len 2000)) :into [] :min-count 1 :max-count 10 :gen-max 5))
-
-(s/def ::fields (s/keys :req-un [:section/fields]))
-
-(s/def :section/accessory
-  (s/or :checkboxes ::elements.spec/checkboxes
-        :datepicker ::elements.spec/datepicker
-        :timepicker ::elements.spec/timepicker
-        :multi-static-select ::elements.spec/multi-static-select
-        :multi-external-select ::elements.spec/multi-external-select
-        :multi-users-select ::elements.spec/multi-users-select
-        :multi-conversations-select ::elements.spec/multi-conversations-select
-        :multi-channels-select ::elements.spec/multi-channels-select
-        :plain-text-input ::elements.spec/plain-text-input
-        :radio-buttons ::elements.spec/radio-buttons
-        :static-select ::elements.spec/static-select
-        :external-select ::elements.spec/external-select
-        :users-select ::elements.spec/users-select
-        :conversations-select ::elements.spec/conversations-select
-        :channels-select ::elements.spec/channels-select
-        :overflow ::elements.spec/overflow
-        :button ::elements.spec/button
-        :image ::elements.spec/image))
+(s/def ::fields (s/keys :req-un [::section/fields]))
 
 (s/def ::section (s/or
-                  :text   (s/keys :req-un [:section/type :section/text] :opt-un [::strings.spec/block_id :section/accessory :section/fields])
-                  :fields (s/keys :req-un [:section/type :section/fields] :opt-un [::strings.spec/block_id :section/accessory :section/text])))
+                  :text   (s/keys :req-un [::section/type ::section/text] :opt-un [::strings.spec/block_id ::section/accessory ::section/fields])
+                  :fields (s/keys :req-un [::section/type ::section/fields] :opt-un [::strings.spec/block_id ::section/accessory ::section/text])))
 
-(s/def :context/type #{:context})
+(s/def ::context (s/keys :req-un [::context/type ::context/elements] :opt-un [::strings.spec/block_id]))
 
-(s/def :context/element (s/or :image ::elements.spec/image :text ::comp.spec/text))
+(s/def ::actions (s/keys :req-un [::actions/type ::actions/elements] :opt-un [::strings.spec/block_id]))
 
-(s/def :context/elements (s/coll-of :context/element :into [] :min-count 1 :max-count 10 :gen-max 5))
-
-(s/def ::context (s/keys :req-un [:context/type :context/elements] :opt-un [::strings.spec/block_id]))
-
-(s/def :actions/type #{:actions})
-
-(s/def :actions/element
-  (s/or :button ::elements.spec/button
-        :checkboxes ::elements.spec/checkboxes
-        :plain-text-input ::elements.spec/plain-text-input
-        :radio-buttons ::elements.spec/radio-buttons
-        :overflow ::elements.spec/overflow
-        :datepicker ::elements.spec/datepicker
-        :timepicker ::elements.spec/timepicker
-        :static-select ::elements.spec/static-select
-        :external-select ::elements.spec/external-select
-        :users-select ::elements.spec/users-select
-        :conversations-select ::elements.spec/conversations-select
-        :channels-select ::elements.spec/channels-select))
-
-(s/def :actions/elements (s/coll-of :actions/element :into [] :min-count 1 :max-count 5 :gen-max 5))
-
-(s/def ::actions (s/keys :req-un [:actions/type :actions/elements] :opt-un [::strings.spec/block_id]))
-
-(s/def :divider/type #{:divider})
-
-(s/def ::divider (s/keys :req-un [:divider/type] :opt-un [::strings.spec/block_id]))
-
-(s/def :file/type #{:file})
-
-(s/def :file/external_id ::strings.spec/string)
-
-(s/def :file/source #{:remote})
+(s/def ::divider (s/keys :req-un [::divider/type] :opt-un [::strings.spec/block_id]))
 
 ;;; file blocks are not directly instantiable at the moment - the spec is defined here even though no component will
 ;;; be defined for rendering.
 
-(s/def ::file (s/keys :req-un [:file/type :file/external_id :file/source] :opt-un [::strings.spec/block_id]))
+(s/def ::file (s/keys :req-un [::file/type ::file/external_id ::file/source] :opt-un [::strings.spec/block_id]))
 
-(s/def :header/type #{:header})
+(s/def ::header (s/keys :req-un [::header/type ::header/text] :opt-un [::strings.spec/block_id]))
 
-(deftext :header/text ::comp.spec/plain-text 150)
+(s/def ::image (s/keys :req-un [::image/type ::image/image_url ::image/alt_text] :opt-un [::image/title ::strings.spec/block_id]))
 
-(s/def ::header (s/keys :req-un [:header/type :header/text] :opt-un [::strings.spec/block_id]))
-
-(s/def :image/type #{:image})
-
-(deftext :image/image_url ::strings.spec/url-string 3000)
-
-(deftext :image/alt_text ::strings.spec/string 2000)
-
-(deftext :image/title ::comp.spec/plain-text 2000)
-
-(s/def ::image (s/keys :req-un [:image/type :image/image_url :image/alt_text] :opt-un [:image/title ::strings.spec/block_id]))
-
-(s/def :input/type #{:input})
-
-(deftext :input/label ::comp.spec/plain-text 2000)
-
-(s/def :input/element
-  (s/or :plain-text-input ::elements.spec/plain-text-input
-        :checkboxes ::elements.spec/checkboxes
-        :radio-buttons ::elements.spec/radio-buttons
-        :datepicker ::elements.spec/datepicker
-        :timepicker ::elements.spec/timepicker
-        :multi-static-select ::elements.spec/multi-static-select
-        :multi-external-select ::elements.spec/multi-external-select
-        :multi-users-select ::elements.spec/multi-users-select
-        :multi-conversations-select ::elements.spec/multi-conversations-select
-        :multi-channels-select ::elements.spec/multi-channels-select
-        :plain-text-input ::elements.spec/plain-text-input
-        :radio-buttons ::elements.spec/radio-buttons
-        :static-select ::elements.spec/static-select
-        :external-select ::elements.spec/external-select
-        :users-select ::elements.spec/users-select
-        :conversations-select ::elements.spec/conversations-select
-        :channels-select ::elements.spec/channels-select))
-
-(s/def :input/dispatch_action boolean?)
-
-(deftext :input/hint ::comp.spec/plain-text 2000)
-
-(s/def :input/optional boolean?)
-
-(s/def ::input (s/keys :req-un [:input/type :input/label :input/element] :opt-un [:input/dispatch_action ::strings.spec/block_id :input/hint :input/optional]))
+(s/def ::input (s/keys :req-un [::input/type ::input/label ::input/element] :opt-un [::input/dispatch_action ::strings.spec/block_id ::input/hint ::input/optional]))
 
 (s/def ::block
   (s/or :actions ::actions

--- a/src/thlack/surfs/blocks/spec/actions.clj
+++ b/src/thlack/surfs/blocks/spec/actions.clj
@@ -1,0 +1,21 @@
+(ns thlack.surfs.blocks.spec.actions
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.elements.spec :as elements.spec]))
+
+(s/def ::type #{:actions})
+
+(s/def ::element
+  (s/or :button ::elements.spec/button
+        :checkboxes ::elements.spec/checkboxes
+        :plain-text-input ::elements.spec/plain-text-input
+        :radio-buttons ::elements.spec/radio-buttons
+        :overflow ::elements.spec/overflow
+        :datepicker ::elements.spec/datepicker
+        :timepicker ::elements.spec/timepicker
+        :static-select ::elements.spec/static-select
+        :external-select ::elements.spec/external-select
+        :users-select ::elements.spec/users-select
+        :conversations-select ::elements.spec/conversations-select
+        :channels-select ::elements.spec/channels-select))
+
+(s/def ::elements (s/coll-of ::element :into [] :min-count 1 :max-count 5 :gen-max 5))

--- a/src/thlack/surfs/blocks/spec/actions.clj
+++ b/src/thlack/surfs/blocks/spec/actions.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.actions
+(ns ^:no-doc thlack.surfs.blocks.spec.actions
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.elements.spec :as elements.spec]))
 

--- a/src/thlack/surfs/blocks/spec/context.clj
+++ b/src/thlack/surfs/blocks/spec/context.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.context
+(ns ^:no-doc thlack.surfs.blocks.spec.context
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.elements.spec :as elements.spec]))

--- a/src/thlack/surfs/blocks/spec/context.clj
+++ b/src/thlack/surfs/blocks/spec/context.clj
@@ -1,0 +1,10 @@
+(ns thlack.surfs.blocks.spec.context
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.elements.spec :as elements.spec]))
+
+(s/def ::type #{:context})
+
+(s/def ::element (s/or :image ::elements.spec/image :text ::comp.spec/text))
+
+(s/def ::elements (s/coll-of ::element :into [] :min-count 1 :max-count 10 :gen-max 5))

--- a/src/thlack/surfs/blocks/spec/divider.clj
+++ b/src/thlack/surfs/blocks/spec/divider.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.blocks.spec.divider
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::type #{:divider})

--- a/src/thlack/surfs/blocks/spec/divider.clj
+++ b/src/thlack/surfs/blocks/spec/divider.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.divider
+(ns ^:no-doc thlack.surfs.blocks.spec.divider
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::type #{:divider})

--- a/src/thlack/surfs/blocks/spec/file.clj
+++ b/src/thlack/surfs/blocks/spec/file.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.blocks.spec.file
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:file})
+
+(s/def ::external_id ::strings.spec/string)
+
+(s/def ::source #{:remote})

--- a/src/thlack/surfs/blocks/spec/file.clj
+++ b/src/thlack/surfs/blocks/spec/file.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.file
+(ns ^:no-doc thlack.surfs.blocks.spec.file
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/blocks/spec/header.clj
+++ b/src/thlack/surfs/blocks/spec/header.clj
@@ -1,0 +1,8 @@
+(ns thlack.surfs.blocks.spec.header
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :refer [deftext]]))
+
+(s/def ::type #{:header})
+
+(deftext ::text ::comp.spec/plain-text 150)

--- a/src/thlack/surfs/blocks/spec/header.clj
+++ b/src/thlack/surfs/blocks/spec/header.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.header
+(ns ^:no-doc thlack.surfs.blocks.spec.header
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/blocks/spec/image.clj
+++ b/src/thlack/surfs/blocks/spec/image.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.image
+(ns ^:no-doc thlack.surfs.blocks.spec.image
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/blocks/spec/image.clj
+++ b/src/thlack/surfs/blocks/spec/image.clj
@@ -1,0 +1,12 @@
+(ns thlack.surfs.blocks.spec.image
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(s/def ::type #{:image})
+
+(deftext ::image_url ::strings.spec/url-string 3000)
+
+(deftext ::alt_text ::strings.spec/string 2000)
+
+(deftext ::title ::comp.spec/plain-text 2000)

--- a/src/thlack/surfs/blocks/spec/input.clj
+++ b/src/thlack/surfs/blocks/spec/input.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.input
+(ns ^:no-doc thlack.surfs.blocks.spec.input
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.elements.spec :as elements.spec]

--- a/src/thlack/surfs/blocks/spec/input.clj
+++ b/src/thlack/surfs/blocks/spec/input.clj
@@ -1,0 +1,34 @@
+(ns thlack.surfs.blocks.spec.input
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.elements.spec :as elements.spec]
+            [thlack.surfs.strings.spec :refer [deftext]]))
+
+(s/def ::type #{:input})
+
+(deftext ::label ::comp.spec/plain-text 2000)
+
+(s/def ::element
+  (s/or :plain-text-input ::elements.spec/plain-text-input
+        :checkboxes ::elements.spec/checkboxes
+        :radio-buttons ::elements.spec/radio-buttons
+        :datepicker ::elements.spec/datepicker
+        :timepicker ::elements.spec/timepicker
+        :multi-static-select ::elements.spec/multi-static-select
+        :multi-external-select ::elements.spec/multi-external-select
+        :multi-users-select ::elements.spec/multi-users-select
+        :multi-conversations-select ::elements.spec/multi-conversations-select
+        :multi-channels-select ::elements.spec/multi-channels-select
+        :plain-text-input ::elements.spec/plain-text-input
+        :radio-buttons ::elements.spec/radio-buttons
+        :static-select ::elements.spec/static-select
+        :external-select ::elements.spec/external-select
+        :users-select ::elements.spec/users-select
+        :conversations-select ::elements.spec/conversations-select
+        :channels-select ::elements.spec/channels-select))
+
+(s/def ::dispatch_action boolean?)
+
+(deftext ::hint ::comp.spec/plain-text 2000)
+
+(s/def ::optional boolean?)

--- a/src/thlack/surfs/blocks/spec/section.clj
+++ b/src/thlack/surfs/blocks/spec/section.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.blocks.spec.section
+(ns ^:no-doc thlack.surfs.blocks.spec.section
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.elements.spec :as elements.spec]

--- a/src/thlack/surfs/blocks/spec/section.clj
+++ b/src/thlack/surfs/blocks/spec/section.clj
@@ -1,0 +1,31 @@
+(ns thlack.surfs.blocks.spec.section
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.elements.spec :as elements.spec]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(s/def ::type #{:section})
+
+(deftext ::text ::comp.spec/text 3000)
+
+(s/def ::fields (s/coll-of (s/and ::comp.spec/text (strings.spec/max-len 2000)) :into [] :min-count 1 :max-count 10 :gen-max 5))
+
+(s/def ::accessory
+  (s/or :checkboxes ::elements.spec/checkboxes
+        :datepicker ::elements.spec/datepicker
+        :timepicker ::elements.spec/timepicker
+        :multi-static-select ::elements.spec/multi-static-select
+        :multi-external-select ::elements.spec/multi-external-select
+        :multi-users-select ::elements.spec/multi-users-select
+        :multi-conversations-select ::elements.spec/multi-conversations-select
+        :multi-channels-select ::elements.spec/multi-channels-select
+        :plain-text-input ::elements.spec/plain-text-input
+        :radio-buttons ::elements.spec/radio-buttons
+        :static-select ::elements.spec/static-select
+        :external-select ::elements.spec/external-select
+        :users-select ::elements.spec/users-select
+        :conversations-select ::elements.spec/conversations-select
+        :channels-select ::elements.spec/channels-select
+        :overflow ::elements.spec/overflow
+        :button ::elements.spec/button
+        :image ::elements.spec/image))

--- a/src/thlack/surfs/composition/components.clj
+++ b/src/thlack/surfs/composition/components.clj
@@ -138,7 +138,7 @@
    [:option {:value \"1\" :description \"Oh hello\"} \"Label\"]
    ```
    
-   Options used in elements supporting initial_option(s), also supported a :selected?
+   Options used in elements supporting initial_option(s), also support a :selected?
    property."
   [props txt]
   (-> props

--- a/src/thlack/surfs/composition/components.clj
+++ b/src/thlack/surfs/composition/components.clj
@@ -6,7 +6,8 @@
             [thlack.surfs.props.spec :as props.spec]
             [thlack.surfs.validation :refer [validated]]
             [thlack.surfs.composition.spec :as comp.spec]
-            [thlack.surfs.composition.components.spec]
+            [thlack.surfs.composition.spec.option-group :as option-group]
+            [thlack.surfs.composition.components.spec :as cc.spec]
             [thlack.surfs.strings.spec :as strings.spec]))
 
 (defn- create-text
@@ -120,7 +121,7 @@
       (validated ::comp.spec/confirm)))
 
 (s/fdef confirm
-  :args (s/cat :props :confirm/props :txt (strings.spec/with-max-gen ::props.spec/text 300))
+  :args (s/cat :props ::cc.spec/confirm.props :txt (strings.spec/with-max-gen ::props.spec/text 300))
   :ret ::comp.spec/confirm)
 
 (defn option
@@ -146,13 +147,8 @@
       (validated ::comp.spec/option)))
 
 (s/fdef option
-  :args (s/cat :props :option/props :txt (strings.spec/with-max-gen ::props.spec/plain-text 75))
+  :args (s/cat :props ::cc.spec/option.props :txt (strings.spec/with-max-gen ::props.spec/plain-text 75))
   :ret ::comp.spec/option)
-
-(s/def :option-group/children
-  (s/with-gen
-    (s/+ ::comp.spec/option)
-    #(s/gen :option-group/options)))
 
 (defn option-group
   "Provides a way to group options in a select menu or multi-select menu.
@@ -170,5 +166,5 @@
               :options (props/flatten-children children)} ::comp.spec/option-group))
 
 (s/fdef option-group
-  :args (s/cat :label :option-group/label :options :option-group/children)
+  :args (s/cat :label ::option-group/label :options ::cc.spec/option-group.children)
   :ret ::comp.spec/option-group)

--- a/src/thlack/surfs/composition/components/spec.clj
+++ b/src/thlack/surfs/composition/components/spec.clj
@@ -1,20 +1,33 @@
 (ns ^:no-doc thlack.surfs.composition.components.spec
   (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.composition.spec.confirm :as confirm]
+            [thlack.surfs.composition.spec.option :as option]
+            [thlack.surfs.composition.spec.option-group :as option-group]
             [thlack.surfs.props.spec :as props.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
 
 ;;; [:confirm]
 
-(deftext :confirm-props/confirm ::strings.spec/string 30)
+(deftext :thlack.surfs.composition.components.spec.confirm-props/confirm ::strings.spec/string 30)
 
-(deftext :confirm-props/deny ::strings.spec/string 30)
+(deftext :thlack.surfs.composition.components.spec.confirm-props/deny ::strings.spec/string 30)
 
-(deftext :confirm-props/title ::strings.spec/string 100)
+(deftext :thlack.surfs.composition.components.spec.confirm-props/title ::strings.spec/string 100)
 
-(s/def :confirm/props (s/keys :req-un [:confirm-props/confirm :confirm-props/deny :confirm-props/title] :opt-un [:confirm/style ::props.spec/disable_emoji_for]))
+(s/def ::confirm.props (s/keys :req-un [:thlack.surfs.composition.components.spec.confirm-props/confirm
+                                        :thlack.surfs.composition.components.spec.confirm-props/deny
+                                        :thlack.surfs.composition.components.spec.confirm-props/title]
+                               :opt-un [::confirm/style
+                                        ::props.spec/disable_emoji_for]))
 
 ;;; [:option]
 
-(deftext :option-props/description ::strings.spec/string 75)
+(deftext :thlack.surfs.composition.components.spec.option-props/description ::strings.spec/string 75)
 
-(s/def :option/props (s/keys :req-un [:option/value] :opt-un [:option-props/description ::props.spec/disable_emoji_for]))
+(s/def ::option.props (s/keys :req-un [::option/value] :opt-un [:thlack.surfs.composition.components.spec.option-props/description
+                                                                ::props.spec/disable_emoji_for]))
+(s/def ::option-group.children
+  (s/with-gen
+    (s/+ ::comp.spec/option)
+    #(s/gen ::option-group/options)))

--- a/src/thlack/surfs/composition/spec.clj
+++ b/src/thlack/surfs/composition/spec.clj
@@ -2,58 +2,23 @@
   "This namespace contains specs for what Slack refers to as
    composition objects"
   (:require [clojure.spec.alpha :as s]
-            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+            [thlack.surfs.composition.spec.plain-text :as plain-text]
+            [thlack.surfs.composition.spec.mrkdwn :as mrkdwn]
+            [thlack.surfs.composition.spec.confirm :as confirm]
+            [thlack.surfs.composition.spec.dispatch-action-config :as dispatch-action-config]
+            [thlack.surfs.composition.spec.option :as option]
+            [thlack.surfs.composition.spec.option-group :as option-group]))
 
-(s/def :plain_text/type #{:plain_text})
+(s/def ::plain-text ::plain-text/plain-text)
 
-(s/def :mrkdwn/type #{:mrkdwn})
-
-(s/def :text/text ::strings.spec/string)
-
-(s/def :text/emoji boolean?)
-
-(s/def :text/verbatim boolean?)
-
-(s/def ::plain-text (s/keys :req-un [:plain_text/type :text/text] :opt-un [:text/emoji]))
-
-(s/def ::mrkdwn (s/keys :req-un [:mrkdwn/type :text/text] :opt-un [:text/verbatim]))
+(s/def ::mrkdwn ::mrkdwn/mrkdwn)
 
 (s/def ::text (s/or :plain_text ::plain-text :mrkdwn ::mrkdwn))
 
-(deftext :confirm/title ::plain-text 100)
+(s/def ::confirm (s/keys :req-un [::confirm/title ::confirm/text ::confirm/confirm ::confirm/deny] :opt-un [::confirm/style]))
 
-(deftext :confirm/text ::text 300)
+(s/def ::dispatch_action_config (s/keys :req-un [::dispatch-action-config/trigger_actions_on]))
 
-(deftext :confirm/confirm ::plain-text 30)
+(s/def ::option ::option/option)
 
-(deftext :confirm/deny ::plain-text 30)
-
-(s/def :confirm/style #{:primary :danger})
-
-(s/def ::confirm (s/keys :req-un [:confirm/title :confirm/text :confirm/confirm :confirm/deny] :opt-un [:confirm/style]))
-
-(s/def :conversation-filter/include (s/coll-of #{:im :mpim :private :public} :distinct true :into [] :gen-max 4 :min-count 1))
-
-(s/def :conversation-filter/exclude_external_shared_channels boolean?)
-
-(s/def :conversation-filter/exclude_bot_users boolean?)
-
-(s/def :conversation/filter (s/keys :opt-un [:conversation-filter/include :conversation-filter/exclude_external_shared_channels :conversation-filter/exclude_bot_users]))
-
-(s/def :dispatch-action-config/trigger_actions_on (s/coll-of #{:on_enter_pressed :on_character_entered} :min-count 1 :distinct true :gen-max 2 :into []))
-
-(s/def ::dispatch_action_config (s/keys :req-un [:dispatch-action-config/trigger_actions_on]))
-
-(deftext :option/text ::plain-text 75)
-
-(deftext :option/value ::strings.spec/string 75)
-
-(deftext :option/description ::plain-text 75)
-
-(s/def ::option (s/keys :req-un [:option/text :option/value] :opt-un [:option/description]))
-
-(deftext :option-group/label ::plain-text 75)
-
-(s/def :option-group/options (s/coll-of ::option :min-count 1 :max-count 100 :into [] :gen-max 10))
-
-(s/def ::option-group (s/keys :req-un [:option-group/label :option-group/options]))
+(s/def ::option-group (s/keys :req-un [::option-group/label ::option-group/options]))

--- a/src/thlack/surfs/composition/spec/confirm.clj
+++ b/src/thlack/surfs/composition/spec/confirm.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.confirm
+(ns ^:no-doc thlack.surfs.composition.spec.confirm
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec.plain-text :as plain-text]
             [thlack.surfs.composition.spec.mrkdwn :as mrkdwn]

--- a/src/thlack/surfs/composition/spec/confirm.clj
+++ b/src/thlack/surfs/composition/spec/confirm.clj
@@ -1,0 +1,17 @@
+(ns thlack.surfs.composition.spec.confirm
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec.plain-text :as plain-text]
+            [thlack.surfs.composition.spec.mrkdwn :as mrkdwn]
+            [thlack.surfs.strings.spec :refer [deftext]]))
+
+(s/def ::text* (s/or :plain_text ::plain-text/plain-text :mrkdwn ::mrkdwn/mrkdwn))
+
+(deftext ::title ::plain-text/plain-text 100)
+
+(deftext ::text ::text* 300)
+
+(deftext ::confirm ::plain-text/plain-text 30)
+
+(deftext ::deny ::plain-text/plain-text 30)
+
+(s/def ::style #{:primary :danger})

--- a/src/thlack/surfs/composition/spec/conversation.clj
+++ b/src/thlack/surfs/composition/spec/conversation.clj
@@ -1,0 +1,10 @@
+(ns thlack.surfs.composition.spec.conversation
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::include (s/coll-of #{:im :mpim :private :public} :distinct true :into [] :gen-max 4 :min-count 1))
+
+(s/def ::exclude_external_shared_channels boolean?)
+
+(s/def ::exclude_bot_users boolean?)
+
+(s/def ::filter (s/keys :opt-un [::include ::exclude_external_shared_channels ::exclude_bot_users]))

--- a/src/thlack/surfs/composition/spec/conversation.clj
+++ b/src/thlack/surfs/composition/spec/conversation.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.conversation
+(ns ^:no-doc thlack.surfs.composition.spec.conversation
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::include (s/coll-of #{:im :mpim :private :public} :distinct true :into [] :gen-max 4 :min-count 1))

--- a/src/thlack/surfs/composition/spec/dispatch_action_config.clj
+++ b/src/thlack/surfs/composition/spec/dispatch_action_config.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.composition.spec.dispatch-action-config
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::trigger_actions_on (s/coll-of #{:on_enter_pressed :on_character_entered} :min-count 1 :distinct true :gen-max 2 :into []))

--- a/src/thlack/surfs/composition/spec/dispatch_action_config.clj
+++ b/src/thlack/surfs/composition/spec/dispatch_action_config.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.dispatch-action-config
+(ns ^:no-doc thlack.surfs.composition.spec.dispatch-action-config
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::trigger_actions_on (s/coll-of #{:on_enter_pressed :on_character_entered} :min-count 1 :distinct true :gen-max 2 :into []))

--- a/src/thlack/surfs/composition/spec/mrkdwn.clj
+++ b/src/thlack/surfs/composition/spec/mrkdwn.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.composition.spec.mrkdwn
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec.text :as text]))
+
+(s/def ::type #{:mrkdwn})
+
+(s/def ::mrkdwn (s/keys :req-un [::type ::text/text] :opt-un [::text/verbatim]))

--- a/src/thlack/surfs/composition/spec/mrkdwn.clj
+++ b/src/thlack/surfs/composition/spec/mrkdwn.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.mrkdwn
+(ns ^:no-doc thlack.surfs.composition.spec.mrkdwn
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec.text :as text]))
 

--- a/src/thlack/surfs/composition/spec/option.clj
+++ b/src/thlack/surfs/composition/spec/option.clj
@@ -1,0 +1,12 @@
+(ns thlack.surfs.composition.spec.option
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec.plain-text :as plain-text]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(deftext ::text ::plain-text/plain-text 75)
+
+(deftext ::value ::strings.spec/string 75)
+
+(deftext ::description ::plain-text/plain-text 75)
+
+(s/def ::option (s/keys :req-un [::text ::value] :opt-un [::description]))

--- a/src/thlack/surfs/composition/spec/option.clj
+++ b/src/thlack/surfs/composition/spec/option.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.option
+(ns ^:no-doc thlack.surfs.composition.spec.option
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec.plain-text :as plain-text]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/composition/spec/option_group.clj
+++ b/src/thlack/surfs/composition/spec/option_group.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.option-group
+(ns ^:no-doc thlack.surfs.composition.spec.option-group
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec.plain-text :as plain-text]
             [thlack.surfs.composition.spec.option :as option]

--- a/src/thlack/surfs/composition/spec/option_group.clj
+++ b/src/thlack/surfs/composition/spec/option_group.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.composition.spec.option-group
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec.plain-text :as plain-text]
+            [thlack.surfs.composition.spec.option :as option]
+            [thlack.surfs.strings.spec :refer [deftext]]))
+
+(deftext ::label ::plain-text/plain-text 75)
+
+(s/def ::options (s/coll-of ::option/option :min-count 1 :max-count 100 :into [] :gen-max 10))

--- a/src/thlack/surfs/composition/spec/plain_text.clj
+++ b/src/thlack/surfs/composition/spec/plain_text.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.composition.spec.plain-text
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec.text :as text]))
+
+(s/def ::type #{:plain_text})
+
+(s/def ::plain-text (s/keys :req-un [::type ::text/text] :opt-un [::text/emoji]))

--- a/src/thlack/surfs/composition/spec/plain_text.clj
+++ b/src/thlack/surfs/composition/spec/plain_text.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.plain-text
+(ns ^:no-doc thlack.surfs.composition.spec.plain-text
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec.text :as text]))
 

--- a/src/thlack/surfs/composition/spec/text.clj
+++ b/src/thlack/surfs/composition/spec/text.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.composition.spec.text
+(ns ^:no-doc thlack.surfs.composition.spec.text
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/composition/spec/text.clj
+++ b/src/thlack/surfs/composition/spec/text.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.composition.spec.text
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::text ::strings.spec/string)
+
+(s/def ::emoji boolean?)
+
+(s/def ::verbatim boolean?)

--- a/src/thlack/surfs/elements/components.clj
+++ b/src/thlack/surfs/elements/components.clj
@@ -6,7 +6,7 @@
             [thlack.surfs.props :as props]
             [thlack.surfs.validation :refer [validated]]
             [thlack.surfs.elements.spec :as elements.spec]
-            [thlack.surfs.elements.components.spec]
+            [thlack.surfs.elements.components.spec :as ec.spec]
             [thlack.surfs.composition.components :as comp]
             [thlack.surfs.composition.spec])
   (:import [java.util UUID]))
@@ -81,13 +81,13 @@
   (let [[props & children] (props/parse-args args)]
     (-> (assoc props :type :button)
         (with-action-id)
-        (props/with-children children :button/child)
+        (props/with-children children ::ec.spec/button.child)
         (comp/with-text #{:text})
         (validated ::elements.spec/button))))
 
 (s/fdef button
-  :args (s/alt :props-and-children (s/cat :props :button/props :children :button/children)
-               :children (s/cat :children :button/children))
+  :args (s/alt :props-and-children (s/cat :props ::ec.spec/button.props :children ::ec.spec/button.children)
+               :children (s/cat :children ::ec.spec/button.children))
   :ret ::elements.spec/button)
 
 (defn checkboxes
@@ -102,13 +102,13 @@
    ```"
   [props & children]
   (-> (assoc props :type :checkboxes)
-      (props/with-children children :checkboxes/child)
+      (props/with-children children ::ec.spec/checkboxes.child)
       (assoc-initial-options)
       (validated ::elements.spec/checkboxes)
       (conform-options)))
 
 (s/fdef checkboxes
-  :args (s/cat :props :checkboxes/props :children :checkboxes/children)
+  :args (s/cat :props ::ec.spec/checkboxes.props :children ::ec.spec/checkboxes.children)
   :ret ::elements.spec/checkboxes)
 
 (defn datepicker
@@ -122,11 +122,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :datepicker)
-      (props/with-children children :datepicker/child)
+      (props/with-children children ::ec.spec/datepicker.child)
       (validated ::elements.spec/datepicker)))
 
 (s/fdef datepicker
-  :args (s/cat :props :datepicker/props :children (s/* :datepicker/child))
+  :args (s/cat :props ::ec.spec/datepicker.props :children (s/* ::ec.spec/datepicker.child))
   :ret ::elements.spec/datepicker)
 
 (defn timepicker
@@ -140,11 +140,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :timepicker)
-      (props/with-children children :timepicker/child)
+      (props/with-children children ::ec.spec/timepicker.child)
       (validated ::elements.spec/timepicker)))
 
 (s/fdef timepicker
-  :args (s/cat :props :timepicker/props :children (s/* :timepicker/child))
+  :args (s/cat :props ::ec.spec/timepicker.props :children (s/* ::ec.spec/timepicker.child))
   :ret ::elements.spec/timepicker)
 
 (defn img
@@ -165,7 +165,7 @@
       (validated ::elements.spec/image)))
 
 (s/fdef img
-  :args (s/cat :props :img/props)
+  :args (s/cat :props ::ec.spec/img.props)
   :ret ::elements.spec/image)
 
 (defn multi-static-select
@@ -197,13 +197,13 @@
    ```"
   [props & children]
   (-> (assoc props :type :multi_static_select)
-      (props/with-children children :multi-static-select/child)
+      (props/with-children children ::ec.spec/multi-static-select.child)
       (assoc-initial-options)
       (validated ::elements.spec/multi-static-select)
       (conform-options)))
 
 (s/fdef multi-static-select
-  :args (s/cat :props :multi-select/props :children :multi-static-select/children)
+  :args (s/cat :props ::ec.spec/multi-select.props :children ::ec.spec/multi-static-select.children)
   :ret  ::elements.spec/multi-static-select)
 
 (defn multi-external-select
@@ -221,7 +221,7 @@
    ```"
   [props & children]
   (-> (assoc props :type :multi_external_select)
-      (props/with-children children :multi-static-select/child)
+      (props/with-children children ::ec.spec/multi-static-select.child)
       (force-selected)
       (assoc-initial-options)
       (dissoc :option_groups :options)
@@ -229,7 +229,7 @@
       (conform-options)))
 
 (s/fdef multi-external-select
-  :args (s/cat :props :multi-external-select/props :children :multi-static-select/children)
+  :args (s/cat :props ::ec.spec/multi-external-select.props :children ::ec.spec/multi-static-select.children)
   :ret ::elements.spec/multi-external-select)
 
 (defn multi-users-select
@@ -243,11 +243,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :multi_users_select)
-      (props/with-children children :slack-select/child)
+      (props/with-children children ::ec.spec/slack-select.child)
       (validated ::elements.spec/multi-users-select)))
 
 (s/fdef multi-users-select
-  :args (s/cat :props :multi-users-select/props :children :slack-select/children)
+  :args (s/cat :props ::ec.spec/multi-users-select.props :children ::ec.spec/slack-select.children)
   :ret ::elements.spec/multi-users-select)
 
 (defn multi-conversations-select
@@ -267,11 +267,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :multi_conversations_select)
-      (props/with-children children :slack-select/child)
+      (props/with-children children ::ec.spec/slack-select.child)
       (validated ::elements.spec/multi-conversations-select)))
 
 (s/fdef multi-conversations-select
-  :args (s/cat :props :multi-conversations-select/props :children :slack-select/children)
+  :args (s/cat :props ::ec.spec/multi-conversations-select.props :children ::ec.spec/slack-select.children)
   :ret ::elements.spec/multi-conversations-select)
 
 (defn multi-channels-select
@@ -285,11 +285,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :multi_channels_select)
-      (props/with-children children :slack-select/child)
+      (props/with-children children ::ec.spec/slack-select.child)
       (validated ::elements.spec/multi-channels-select)))
 
 (s/fdef multi-channels-select
-  :args (s/cat :props :multi-channels-select/props :children :slack-select/children)
+  :args (s/cat :props ::ec.spec/multi-channels-select.props :children ::ec.spec/slack-select.children)
   :ret ::elements.spec/multi-channels-select)
 
 (defn static-select
@@ -321,13 +321,13 @@
    ```"
   [props & children]
   (-> (assoc props :type :static_select)
-      (props/with-children children :static-select/child)
+      (props/with-children children ::ec.spec/static-select.child)
       (assoc-initial-options)
       (validated ::elements.spec/static-select)
       (conform-options)))
 
 (s/fdef static-select
-  :args (s/cat :props :static-select/props :children :static-select/children)
+  :args (s/cat :props ::ec.spec/static-select.props :children ::ec.spec/static-select.children)
   :ret ::elements.spec/static-select)
 
 (defn external-select
@@ -344,7 +344,7 @@
    ```"
   [props & children]
   (-> (assoc props :type :external_select)
-      (props/with-children children :static-select/child)
+      (props/with-children children ::ec.spec/static-select.child)
       (force-selected)
       (assoc-initial-options)
       (dissoc :options)
@@ -352,7 +352,7 @@
       (conform-options)))
 
 (s/fdef external-select
-  :args (s/cat :props :external-select/props :children :static-select/children)
+  :args (s/cat :props ::ec.spec/external-select.props :children ::ec.spec/static-select.children)
   :ret  ::elements.spec/external-select)
 
 (defn users-select
@@ -366,11 +366,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :users_select)
-      (props/with-children children :slack-select/child)
+      (props/with-children children ::ec.spec/slack-select.child)
       (validated ::elements.spec/users-select)))
 
 (s/fdef users-select
-  :args (s/cat :props :users-select/props :children :slack-select/children)
+  :args (s/cat :props ::ec.spec/users-select.props :children ::ec.spec/slack-select.children)
   :ret ::elements.spec/users-select)
 
 (defn conversations-select
@@ -389,11 +389,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :conversations_select)
-      (props/with-children children :slack-select/child)
+      (props/with-children children ::ec.spec/slack-select.child)
       (validated ::elements.spec/conversations-select)))
 
 (s/fdef conversations-select
-  :args (s/cat :props :conversations-select/props :children :slack-select/children)
+  :args (s/cat :props ::ec.spec/conversations-select.props :children ::ec.spec/slack-select.children)
   :ret ::elements.spec/conversations-select)
 
 (defn channels-select
@@ -407,11 +407,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :channels_select)
-      (props/with-children children :slack-select/child)
+      (props/with-children children ::ec.spec/slack-select.child)
       (validated ::elements.spec/channels-select)))
 
 (s/fdef channels-select
-  :args (s/cat :props :channels-select/props :children :slack-select/children)
+  :args (s/cat :props ::ec.spec/channels-select.props :children ::ec.spec/slack-select.children)
   :ret ::elements.spec/channels-select)
 
 (defn overflow
@@ -436,15 +436,15 @@
     [:option {:value \"3\" :url \"https://duckduckgo.com\"} \"DuckDuckGo\"]]
    ```"
   [& args]
-  (let [[props & children] (props/parse-args args :overflow/props*)]
+  (let [[props & children] (props/parse-args args ::ec.spec/overflow.props*)]
     (-> (assoc props :type :overflow)
         (with-action-id)
-        (props/with-children children :overflow/child)
+        (props/with-children children ::ec.spec/overflow.child)
         (validated ::elements.spec/overflow))))
 
 (s/fdef overflow
-  :args (s/alt :props-and-children (s/cat :props :overflow/props :children :overflow/children)
-               :children (s/cat :children :overflow/children))
+  :args (s/alt :props-and-children (s/cat :props ::ec.spec/overflow.props :children ::ec.spec/overflow.children)
+               :children (s/cat :children ::ec.spec/overflow.children))
   :ret ::elements.spec/overflow)
 
 (defn plain-text-input
@@ -464,11 +464,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :plain_text_input)
-      (props/with-children children :plain-text-input/child)
+      (props/with-children children ::ec.spec/plain-text-input.child)
       (validated ::elements.spec/plain-text-input)))
 
 (s/fdef plain-text-input
-  :args (s/cat :props :plain-text-input/props :children :plain-text-input/children)
+  :args (s/cat :props ::ec.spec/plain-text-input.props :children ::ec.spec/plain-text-input.children)
   :ret ::elements.spec/plain-text-input)
 
 (defn radio-buttons
@@ -484,11 +484,11 @@
    ```"
   [props & children]
   (-> (assoc props :type :radio_buttons)
-      (props/with-children children :radio-buttons/child)
+      (props/with-children children ::ec.spec/radio-buttons.child)
       (assoc-initial-options)
       (validated ::elements.spec/radio-buttons)
       (conform-options)))
 
 (s/fdef radio-buttons
-  :args (s/cat :props :radio-buttons/props :children :radio-buttons/children)
+  :args (s/cat :props ::ec.spec/radio-buttons.props :children ::ec.spec/radio-buttons.children)
   :ret ::elements.spec/radio-buttons)

--- a/src/thlack/surfs/elements/components/spec.clj
+++ b/src/thlack/surfs/elements/components/spec.clj
@@ -2,7 +2,23 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.composition.spec.conversation :as conversation]
             [thlack.surfs.elements.spec :as elements.spec]
+            [thlack.surfs.elements.spec.button :as button]
+            [thlack.surfs.elements.spec.datepicker :as datepicker]
+            [thlack.surfs.elements.spec.overflow :as overflow]
+            [thlack.surfs.elements.spec.timepicker :as timepicker]
+            [thlack.surfs.elements.spec.image :as image]
+            [thlack.surfs.elements.spec.conversations-select :as conversations-select]
+            [thlack.surfs.elements.spec.multi-select :as multi-select]
+            [thlack.surfs.elements.spec.external-select :as external-select]
+            [thlack.surfs.elements.spec.multi-conversations-select :as multi-conversations-select]
+            [thlack.surfs.elements.spec.multi-users-select :as multi-users-select]
+            [thlack.surfs.elements.spec.multi-channels-select :as multi-channels-select]
+            [thlack.surfs.elements.spec.users-select :as users-select]
+            [thlack.surfs.elements.spec.select :as select]
+            [thlack.surfs.elements.spec.channels-select :as channels-select]
+            [thlack.surfs.elements.spec.plain-text-input :as plain-text-input]
             [thlack.surfs.props.spec :as props.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
 
@@ -16,51 +32,51 @@
 
 ;;; [:button]
 
-(deftext :button-child/text ::props.spec/plain-text 75)
+(deftext :thlack.surfs.elements.components.spec.button-child/text ::props.spec/plain-text 75)
 
-(s/def :button/child
-  (s/or :plain-text :button-child/text
+(s/def ::button.child
+  (s/or :plain-text :thlack.surfs.elements.components.spec.button-child/text
         :confirm    ::comp.spec/confirm))
 
-(s/def :button/children
+(s/def ::button.children
   (s/with-gen
-    (s/* :button/child)
-    #(gen/tuple (s/gen :button-child/text) (s/gen ::comp.spec/confirm))))
+    (s/* ::button.child)
+    #(gen/tuple (s/gen :thlack.surfs.elements.components.spec.button-child/text) (s/gen ::comp.spec/confirm))))
 
-(s/def :button/props (s/keys :opt-un [:button/url :button/style :button/value ::strings.spec/action_id]))
+(s/def ::button.props (s/keys :opt-un [::button/url ::button/style ::button/value ::strings.spec/action_id]))
 
 ;;; [:checkboxes]
 
-(s/def :checkboxes/child
+(s/def ::checkboxes.child
   (s/or :option  ::option
         :confirm ::comp.spec/confirm))
 
-(s/def :checkboxes/children
+(s/def ::checkboxes.children
   (s/with-gen
-    (s/* :checkboxes/child)
+    (s/* ::checkboxes.child)
     #(gen/tuple (s/gen ::option) (s/gen ::option) (s/gen ::comp.spec/confirm))))
 
-(s/def :checkboxes/props (s/keys :req-un [::strings.spec/action_id]))
+(s/def ::checkboxes.props (s/keys :req-un [::strings.spec/action_id]))
 
 ;;; [:datepicker]
 
-(s/def :datepicker/child
+(s/def ::datepicker.child
   (s/or :placeholder ::comp.spec/plain-text
         :confirm     ::comp.spec/confirm))
 
-(s/def :datepicker/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:datepicker/initial_date]))
+(s/def ::datepicker.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::datepicker/initial_date]))
 
 ;;; [:timepicker]
 
-(s/def :timepicker/child
+(s/def ::timepicker.child
   (s/or :placeholder ::comp.spec/plain-text
         :confirm     ::comp.spec/confirm))
 
-(s/def :timepicker/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:timepicker/initial_time]))
+(s/def ::timepicker.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::timepicker/initial_time]))
 
 ;;; [:img]
 
-(s/def :img/props (s/keys :req-un [:image/image_url :image/alt_text]))
+(s/def ::img.props (s/keys :req-un [::image/image_url ::image/alt_text]))
 
 (defn gen-option-parent
   "Returns a generator that yields samples
@@ -80,99 +96,99 @@
 
 ;;; [:multi-static-select]
 
-(s/def :multi-static-select/child
+(s/def ::multi-static-select.child
   (s/or :placeholder  ::comp.spec/plain-text
         :option       ::option
         :option-group ::option-group
         :confirm      ::comp.spec/confirm))
 
-(s/def :multi-static-select/children
+(s/def ::multi-static-select.children
   (s/with-gen
-    (s/* :multi-static-select/child)
+    (s/* ::multi-static-select.child)
     #(gen-option-parent ::elements.spec/multi-static-select [:confirm :placeholder])))
 
-(s/def :multi-select/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:multi-select/max_selected_items]))
+(s/def ::multi-select.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::multi-select/max_selected_items]))
 
-(s/def :slack-select/child
+(s/def ::slack-select.child
   (s/or :placeholder ::comp.spec/plain-text
         :confirm     ::comp.spec/confirm))
 
-(s/def :slack-select/children
+(s/def ::slack-select.children
   (s/with-gen
-    (s/* :slack-select/child)
+    (s/* ::slack-select.child)
     #(gen/tuple (s/gen ::comp.spec/plain-text) (s/gen ::comp.spec/confirm))))
 
 ;;; [:multi-external-select]
 
-(s/def :multi-external-select/props (s/merge :multi-select/props (s/keys :opt-un [:external-select/min_query_length])))
+(s/def ::multi-external-select.props (s/merge ::multi-select.props (s/keys :opt-un [::external-select/min_query_length])))
 
 ;;; [:multi-users-select]
 
-(s/def :multi-users-select/props (s/merge :multi-select/props (s/keys :opt-un [:multi-users-select/initial_users])))
+(s/def ::multi-users-select.props (s/merge ::multi-select.props (s/keys :opt-un [::multi-users-select/initial_users])))
 
 ;;; [:multi-conversations-select]
 
-(s/def :multi-conversations-select/props (s/merge :multi-select/props (s/keys :opt-un [:multi-conversations-select/initial_conversations :conversations-select/default_to_current_conversation :conversation/filter])))
+(s/def ::multi-conversations-select.props (s/merge ::multi-select.props (s/keys :opt-un [::multi-conversations-select/initial_conversations ::conversations-select/default_to_current_conversation ::conversation/filter])))
 
 ;;; [:multi-channels-select]
 
-(s/def :multi-channels-select/props (s/merge :multi-select/props (s/keys :opt-un [:multi-channels-select/initial_channels])))
+(s/def ::multi-channels-select.props (s/merge ::multi-select.props (s/keys :opt-un [::multi-channels-select/initial_channels])))
 
 ;;; [:static-select]
 
-(s/def :static-select/child
+(s/def ::static-select.child
   (s/or :confirm      ::comp.spec/confirm
         :placeholder  ::comp.spec/plain-text
         :option       ::option
         :option-group ::option-group))
 
-(s/def :static-select/children
+(s/def ::static-select.children
   (s/with-gen
-    (s/* :static-select/child)
+    (s/* ::static-select.child)
     #(gen-option-parent ::elements.spec/static-select [:confirm :placeholder])))
 
-(s/def :static-select/props (s/keys :req-un [::strings.spec/action_id]))
+(s/def ::static-select.props (s/keys :req-un [::strings.spec/action_id]))
 
 ;;; [:external-select]
 
-(s/def :external-select/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:external-select/min_query_length]))
+(s/def ::external-select.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::external-select/min_query_length]))
 
 ;;; [:users-select]
 
-(s/def :users-select/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:users-select/initial_user]))
+(s/def ::users-select.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::users-select/initial_user]))
 
 ;;; [:conversations-select]
 
-(s/def :conversations-select/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:conversations-select/initial_conversation :conversations-select/default_to_current_conversation :select/response_url_enabled :conversation/filter]))
+(s/def ::conversations-select.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::conversations-select/initial_conversation ::conversations-select/default_to_current_conversation ::select/response_url_enabled ::conversation/filter]))
 
 ;;; [:channels-select]
 
-(s/def :channels-select/props (s/keys :req-un [::strings.spec/action_id] :opt-un [:select/response_url_enabled :channels-select/initial_channel]))
+(s/def ::channels-select.props (s/keys :req-un [::strings.spec/action_id] :opt-un [::select/response_url_enabled ::channels-select/initial_channel]))
 
 ;;; [:overflow]
 
-(s/def :overflow/child
+(s/def ::overflow.child
   (s/or :confirm ::comp.spec/confirm
-        :option  :overflow/option))
+        :option  ::overflow/option))
 
-(s/def :overflow/children
+(s/def ::overflow.children
   (s/with-gen
-    (s/* :overflow/child)
+    (s/* ::overflow.child)
     #(gen-option-parent ::elements.spec/overflow [:confirm])))
 
-(s/def :overflow/props (s/keys :opt-un [::strings.spec/action_id]))
+(s/def ::overflow.props (s/keys :opt-un [::strings.spec/action_id]))
 
 ; Internal use only - used for validating overflow prop maps that MUST contain action_id in order to be considered props
-(s/def :overflow/props* (s/keys :req-un [::strings.spec/action_id]))
+(s/def ::overflow.props* (s/keys :req-un [::strings.spec/action_id]))
 
 ;;; [:plain-text-input]
 
-(s/def :plain-text-input/child
+(s/def ::plain-text-input.child
   (s/or :placeholder ::comp.spec/plain-text))
 
-(s/def :plain-text-input/children
+(s/def ::plain-text-input.children
   (s/with-gen
-    (s/* :plain-text-input/child)
+    (s/* ::plain-text-input.child)
     #(gen/fmap
       (fn [props]
         (->> (select-keys props [:placeholder])
@@ -180,24 +196,24 @@
              (filter some?)))
       (s/gen ::elements.spec/plain-text-input))))
 
-(s/def :plain-text-input/props* (s/keys :req-un [::strings.spec/action_id] :opt-un [:plain-text-input/initial_value :plain-text-input/multiline :plain-text-input/min_length :plain-text-input/max_length ::comp.spec/dispatch_action_config]))
+(s/def ::plain-text-input.props* (s/keys :req-un [::strings.spec/action_id] :opt-un [::plain-text-input/initial_value ::plain-text-input/multiline ::plain-text-input/min_length ::plain-text-input/max_length ::comp.spec/dispatch_action_config]))
 
-(s/def :plain-text-input/props (s/with-gen
-                                 :plain-text-input/props*
-                                 #(gen/fmap
-                                   (fn [props]
-                                     (select-keys props [:action_id :initial_value :multiline :min_length :max_length :dispatch_action_config]))
-                                   (s/gen ::elements.spec/plain-text-input))))
+(s/def ::plain-text-input.props (s/with-gen
+                                  ::plain-text-input.props*
+                                  #(gen/fmap
+                                    (fn [props]
+                                      (select-keys props [:action_id :initial_value :multiline :min_length :max_length :dispatch_action_config]))
+                                    (s/gen ::elements.spec/plain-text-input))))
 
 ;;; [:radio-buttons]
 
-(s/def :radio-buttons/child
+(s/def ::radio-buttons.child
   (s/or :option  ::comp.spec/option
         :confirm ::comp.spec/confirm))
 
-(s/def :radio-buttons/children
+(s/def ::radio-buttons.children
   (s/with-gen
-    (s/* :radio-buttons/child)
+    (s/* ::radio-buttons.child)
     #(gen-option-parent ::elements.spec/radio-buttons [:confirm])))
 
-(s/def :radio-buttons/props (s/keys :req-un [::strings.spec/action_id]))
+(s/def ::radio-buttons.props (s/keys :req-un [::strings.spec/action_id]))

--- a/src/thlack/surfs/elements/spec.clj
+++ b/src/thlack/surfs/elements/spec.clj
@@ -2,31 +2,38 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
             [thlack.surfs.composition.spec :as comp.spec]
-            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+            [thlack.surfs.composition.spec.conversation :as conversation]
+            [thlack.surfs.elements.spec.button :as button]
+            [thlack.surfs.elements.spec.checkboxes :as checkboxes]
+            [thlack.surfs.elements.spec.datepicker :as datepicker]
+            [thlack.surfs.elements.spec.select :as select]
+            [thlack.surfs.elements.spec.external-select :as external-select]
+            [thlack.surfs.elements.spec.conversations-select :as conversations-select]
+            [thlack.surfs.elements.spec.multi-select :as multi-select]
+            [thlack.surfs.elements.spec.multi-static-select :as multi-static-select]
+            [thlack.surfs.elements.spec.multi-external-select :as multi-external-select]
+            [thlack.surfs.elements.spec.multi-users-select :as multi-users-select]
+            [thlack.surfs.elements.spec.multi-conversations-select :as multi-conversations-select]
+            [thlack.surfs.elements.spec.multi-channels-select :as multi-channels-select]
+            [thlack.surfs.elements.spec.overflow :as overflow]
+            [thlack.surfs.elements.spec.plain-text-input :as plain-text-input]
+            [thlack.surfs.elements.spec.radio-buttons :as radio-buttons]
+            [thlack.surfs.elements.spec.static-select :as static-select]
+            [thlack.surfs.elements.spec.users-select :as users-select]
+            [thlack.surfs.elements.spec.channels-select :as channels-select]
+            [thlack.surfs.elements.spec.timepicker :as timepicker]
+            [thlack.surfs.elements.spec.image :as image]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(defn generate
+  [spec]
+  (gen/generate (s/gen spec)))
 
 ;;; Interactive components
 
-(s/def :button/type #{:button})
+(s/def ::button (s/keys :req-un [::button/type ::button/text ::strings.spec/action_id] :opt-un [::button/url ::button/value ::button/style ::comp.spec/confirm]))
 
-(deftext :button/text ::comp.spec/plain-text 75)
-
-(s/def :button/action_id ::strings.spec/action_id)
-
-(deftext :button/url ::strings.spec/url-string 3000)
-
-(deftext :button/value ::strings.spec/string 2000)
-
-(s/def :button/style #{:primary :danger})
-
-(s/def ::button (s/keys :req-un [:button/type :button/text ::strings.spec/action_id] :opt-un [:button/url :button/value :button/style ::comp.spec/confirm]))
-
-(s/def :checkboxes/type #{:checkboxes})
-
-(s/def :checkboxes/options (s/coll-of ::comp.spec/option :into [] :min-count 1 :max-count 10))
-
-(s/def :checkboxes/initial_options :checkboxes/options)
-
-(s/def ::checkboxes* (s/keys :req-un [:checkboxes/type ::strings.spec/action_id :checkboxes/options] :opt-un [:checkboxes/initial_options ::comp.spec/confirm]))
+(s/def ::checkboxes* (s/keys :req-un [::checkboxes/type ::strings.spec/action_id ::checkboxes/options] :opt-un [::checkboxes/initial_options ::comp.spec/confirm]))
 
 (defn valid-initial-options?
   "Initial options MUST be a sample from options. Supports giving a key if
@@ -48,13 +55,7 @@
                             checkboxes))
                         (s/gen ::checkboxes*))))
 
-(s/def :datepicker/type #{:datepicker})
-
-(deftext :datepicker/placeholder ::comp.spec/plain-text 150)
-
-(s/def :datepicker/initial_date ::strings.spec/date-string)
-
-(s/def ::datepicker (s/keys :req-un [:datepicker/type ::strings.spec/action_id] :opt-un [:datepicker/placeholder :datepicker/initial_date ::comp.spec/confirm]))
+(s/def ::datepicker (s/keys :req-un [::datepicker/type ::strings.spec/action_id] :opt-un [::datepicker/placeholder ::datepicker/initial_date ::comp.spec/confirm]))
 
 (defn gen-select
   ([spec k]
@@ -75,79 +76,25 @@
                                            (mapcat :options))))
     (valid-initial-options? element :options)))
 
-(deftext :select/placeholder ::comp.spec/plain-text 150)
-
-(s/def :select/options (s/coll-of ::comp.spec/option :max-count 100 :min-count 1 :into [] :gen-max 5))
-
-(s/def :select/option_groups (s/coll-of ::comp.spec/option-group :max-count 100 :min-count 1 :into [] :gen-max 5))
-
-(s/def :select/initial_option ::comp.spec/option)
-
-(s/def :select/initial_options :select/options)
-
-(s/def :select/response_url_enabled boolean?)
-
-(s/def :external-select/min_query_length pos-int?)
-
-(s/def :conversations-select/default_to_current_conversation boolean?)
-
-(s/def :multi-select/max_selected_items pos-int?)
-
-(s/def :multi-static-select/type #{:multi_static_select})
-
 (s/def ::multi-static-select*
-  (s/keys :req-un [:multi-static-select/type :select/placeholder ::strings.spec/action_id (or :select/options :select/option_groups)]
-          :opt-un [::comp.spec/confirm :multi-select/max_selected_items :select/initial_options]))
+  (s/keys :req-un [::multi-static-select/type ::select/placeholder ::strings.spec/action_id (or ::select/options ::select/option_groups)]
+          :opt-un [::comp.spec/confirm ::multi-select/max_selected_items ::select/initial_options]))
 
 (s/def ::multi-static-select (s/with-gen
                                (s/and ::multi-static-select* valid-select-options?)
                                #(gen-select ::multi-static-select*)))
 
-(s/def :multi-external-select/type #{:multi_external_select})
+(s/def ::multi-external-select (s/keys :req-un [::multi-external-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::external-select/min_query_length ::comp.spec/confirm ::multi-select/max_selected_items ::select/initial_options]))
 
-(s/def ::multi-external-select (s/keys :req-un [:multi-external-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:external-select/min_query_length ::comp.spec/confirm :multi-select/max_selected_items :select/initial_options]))
+(s/def ::multi-users-select (s/keys :req-un [::multi-users-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::multi-users-select/initial_users ::comp.spec/confirm ::multi-select/max_selected_items]))
 
-(s/def :multi-users-select/type #{:multi_users_select})
+(s/def ::multi-conversations-select (s/keys :req-un [::multi-conversations-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::multi-conversations-select/initial_conversations ::conversations-select/default_to_current_conversation ::comp.spec/confirm ::multi-select/max_selected_items ::conversation/filter]))
 
-(s/def :multi-users-select/initial_users (s/coll-of ::strings.spec/id :into [] :gen-max 10 :min-count 1))
+(s/def ::multi-channels-select (s/keys :req-un [::multi-channels-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::multi-channels-select/initial_channels ::comp.spec/confirm ::multi-select/max_selected_items]))
 
-(s/def ::multi-users-select (s/keys :req-un [:multi-users-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:multi-users-select/initial_users ::comp.spec/confirm :multi-select/max_selected_items]))
+(s/def ::overflow (s/keys :req-un [::overflow/type ::strings.spec/action_id ::overflow/options] :opt-un [::comp.spec/confirm]))
 
-(s/def :multi-conversations-select/type #{:multi_conversations_select})
-
-(s/def :multi-conversations-select/initial_conversations (s/coll-of ::strings.spec/id :into [] :gen-max 5 :min-count 1))
-
-(s/def ::multi-conversations-select (s/keys :req-un [:multi-conversations-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:multi-conversations-select/initial_conversations :conversations-select/default_to_current_conversation ::comp.spec/confirm :multi-select/max_selected_items :conversation/filter]))
-
-(s/def :multi-channels-select/type #{:multi_channels_select})
-
-(s/def :multi-channels-select/initial_channels (s/coll-of ::strings.spec/id :into [] :gen-max 10 :min-count 1))
-
-(s/def ::multi-channels-select (s/keys :req-un [:multi-channels-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:multi-channels-select/initial_channels ::comp.spec/confirm :multi-select/max_selected_items]))
-
-(s/def :overflow/type #{:overflow})
-
-(s/def :overflow/url (s/and ::strings.spec/url-string (strings.spec/max-len 3000)))
-
-(s/def :overflow/option (s/merge ::comp.spec/option (s/keys :opt-un [:overflow/url])))
-
-(s/def :overflow/options (s/coll-of :overflow/option :into [] :min-count 2 :max-count 5 :gen-max 3))
-
-(s/def ::overflow (s/keys :req-un [:overflow/type ::strings.spec/action_id :overflow/options] :opt-un [::comp.spec/confirm]))
-
-(s/def :plain-text-input/type #{:plain_text_input})
-
-(deftext :plain-text-input/placeholder ::comp.spec/plain-text 150)
-
-(s/def :plain-text-input/initial_value ::strings.spec/string)
-
-(s/def :plain-text-input/multiline boolean?)
-
-(s/def :plain-text-input/min_length (s/int-in 1 3001))
-
-(s/def :plain-text-input/max_length pos-int?)
-
-(s/def ::plain-text-input* (s/keys :req-un [:plain-text-input/type ::strings.spec/action_id] :opt-un [:plain-text-input/placeholder :plain-text-input/initial_value :plain-text-input/multiline :plain-text-input/min_length :plain-text-input/max_length ::comp.spec/dispatch_action_config]))
+(s/def ::plain-text-input* (s/keys :req-un [::plain-text-input/type ::strings.spec/action_id] :opt-un [::plain-text-input/placeholder ::plain-text-input/initial_value ::plain-text-input/multiline ::plain-text-input/min_length ::plain-text-input/max_length ::comp.spec/dispatch_action_config]))
 
 (defn max-gte-min?
   [{:keys [min_length max_length] :or {min_length 0 max_length 1}}]
@@ -162,13 +109,7 @@
                                   element))
                               (s/gen ::plain-text-input*))))
 
-(s/def :radio-buttons/type #{:radio_buttons})
-
-(s/def :radio-buttons/options (s/coll-of ::comp.spec/option :into [] :min-count 1 :max-count 10 :gen-max 5))
-
-(s/def :radio-buttons/initial_option ::comp.spec/option)
-
-(s/def ::radio-buttons* (s/keys :req-un [:radio-buttons/type ::strings.spec/action_id :radio-buttons/options] :opt-un [:radio-buttons/initial_option ::comp.spec/confirm]))
+(s/def ::radio-buttons* (s/keys :req-un [::radio-buttons/type ::strings.spec/action_id ::radio-buttons/options] :opt-un [::radio-buttons/initial_option ::comp.spec/confirm]))
 
 (s/def ::radio-buttons (s/with-gen
                          (s/and ::radio-buttons* valid-initial-options?)
@@ -179,50 +120,22 @@
                                element))
                            (s/gen ::radio-buttons*))))
 
-(s/def :static-select/type #{:static_select})
-
 (s/def ::static-select*
-  (s/keys :req-un [:static-select/type :select/placeholder ::strings.spec/action_id (or :select/options :select/option_groups)]
-          :opt-un [:select/initial_option ::comp.spec/confirm]))
+  (s/keys :req-un [::static-select/type ::select/placeholder ::strings.spec/action_id (or ::select/options ::select/option_groups)]
+          :opt-un [::select/initial_option ::comp.spec/confirm]))
 
 (s/def ::static-select (s/with-gen
                          (s/and ::static-select* valid-select-options?)
                          #(gen-select ::static-select*)))
 
-(s/def :external-select/type #{:external_select})
+(s/def ::external-select (s/keys :req-un [::external-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::select/initial_option ::external-select/min_query_length ::comp.spec/confirm]))
 
-(s/def ::external-select (s/keys :req-un [:external-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:select/initial_option :external-select/min_query_length ::comp.spec/confirm]))
+(s/def ::users-select (s/keys :req-un [::users-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::users-select/initial_user ::comp.spec/confirm]))
 
-(s/def :users-select/type #{:users_select})
+(s/def ::conversations-select (s/keys :req-un [::conversations-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::conversations-select/initial_conversation ::conversations-select/default_to_current_conversation ::comp.spec/confirm ::select/response_url_enabled ::conversation/filter]))
 
-(s/def :users-select/initial_user ::strings.spec/id)
+(s/def ::channels-select (s/keys :req-un [::channels-select/type ::select/placeholder ::strings.spec/action_id] :opt-un [::channels-select/initial_channel ::comp.spec/confirm ::select/response_url_enabled]))
 
-(s/def ::users-select (s/keys :req-un [:users-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:users-select/initial_user ::comp.spec/confirm]))
+(s/def ::timepicker (s/keys :req-un [::timepicker/type ::strings.spec/action_id] :opt-un [::timepicker/placeholder ::timepicker/initial_time ::comp.spec/confirm]))
 
-(s/def :conversations-select/type #{:conversations_select})
-
-(s/def :conversations-select/initial_conversation ::strings.spec/id)
-
-(s/def ::conversations-select (s/keys :req-un [:conversations-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:conversations-select/initial_conversation :conversations-select/default_to_current_conversation ::comp.spec/confirm :select/response_url_enabled :conversation/filter]))
-
-(s/def :channels-select/type #{:channels_select})
-
-(s/def :channels-select/initial_channel ::strings.spec/id)
-
-(s/def ::channels-select (s/keys :req-un [:channels-select/type :select/placeholder ::strings.spec/action_id] :opt-un [:channels-select/initial_channel ::comp.spec/confirm :select/response_url_enabled]))
-
-(s/def :timepicker/type #{:timepicker})
-
-(s/def :timepicker/initial_time ::strings.spec/time-string)
-
-(deftext :timepicker/placeholder ::comp.spec/plain-text 150)
-
-(s/def ::timepicker (s/keys :req-un [:timepicker/type ::strings.spec/action_id] :opt-un [:timepicker/placeholder :timepicker/initial_time ::comp.spec/confirm]))
-
-(s/def :image/type #{:image})
-
-(s/def :image/image_url ::strings.spec/url-string)
-
-(s/def :image/alt_text ::strings.spec/string)
-
-(s/def ::image (s/keys :req-un [:image/type :image/image_url :image/alt_text]))
+(s/def ::image (s/keys :req-un [::image/type ::image/image_url ::image/alt_text]))

--- a/src/thlack/surfs/elements/spec/button.clj
+++ b/src/thlack/surfs/elements/spec/button.clj
@@ -1,0 +1,16 @@
+(ns thlack.surfs.elements.spec.button
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(s/def ::type #{:button})
+
+(deftext ::text ::comp.spec/plain-text 75)
+
+(s/def ::action_id ::strings.spec/action_id)
+
+(deftext ::url ::strings.spec/url-string 3000)
+
+(deftext ::value ::strings.spec/string 2000)
+
+(s/def ::style #{:primary :danger})

--- a/src/thlack/surfs/elements/spec/button.clj
+++ b/src/thlack/surfs/elements/spec/button.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.button
+(ns ^:no-doc thlack.surfs.elements.spec.button
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/elements/spec/channels_select.clj
+++ b/src/thlack/surfs/elements/spec/channels_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.channels-select
+(ns ^:no-doc thlack.surfs.elements.spec.channels-select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/channels_select.clj
+++ b/src/thlack/surfs/elements/spec/channels_select.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.elements.spec.channels-select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:channels_select})
+
+(s/def ::initial_channel ::strings.spec/id)

--- a/src/thlack/surfs/elements/spec/checkboxes.clj
+++ b/src/thlack/surfs/elements/spec/checkboxes.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.elements.spec.checkboxes
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]))
+
+(s/def ::type #{:checkboxes})
+
+(s/def ::options (s/coll-of ::comp.spec/option :into [] :min-count 1 :max-count 10))
+
+(s/def ::initial_options ::options)

--- a/src/thlack/surfs/elements/spec/checkboxes.clj
+++ b/src/thlack/surfs/elements/spec/checkboxes.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.checkboxes
+(ns ^:no-doc thlack.surfs.elements.spec.checkboxes
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]))
 

--- a/src/thlack/surfs/elements/spec/conversations_select.clj
+++ b/src/thlack/surfs/elements/spec/conversations_select.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.elements.spec.conversations-select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:conversations_select})
+
+(s/def ::initial_conversation ::strings.spec/id)
+
+(s/def ::default_to_current_conversation boolean?)

--- a/src/thlack/surfs/elements/spec/conversations_select.clj
+++ b/src/thlack/surfs/elements/spec/conversations_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.conversations-select
+(ns ^:no-doc thlack.surfs.elements.spec.conversations-select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/datepicker.clj
+++ b/src/thlack/surfs/elements/spec/datepicker.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.datepicker
+(ns ^:no-doc thlack.surfs.elements.spec.datepicker
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/elements/spec/datepicker.clj
+++ b/src/thlack/surfs/elements/spec/datepicker.clj
@@ -1,0 +1,10 @@
+(ns thlack.surfs.elements.spec.datepicker
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(s/def ::type #{:datepicker})
+
+(deftext ::placeholder ::comp.spec/plain-text 150)
+
+(s/def ::initial_date ::strings.spec/date-string)

--- a/src/thlack/surfs/elements/spec/external_select.clj
+++ b/src/thlack/surfs/elements/spec/external_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.external-select
+(ns ^:no-doc thlack.surfs.elements.spec.external-select
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::type #{:external_select})

--- a/src/thlack/surfs/elements/spec/external_select.clj
+++ b/src/thlack/surfs/elements/spec/external_select.clj
@@ -1,0 +1,6 @@
+(ns thlack.surfs.elements.spec.external-select
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::type #{:external_select})
+
+(s/def ::min_query_length pos-int?)

--- a/src/thlack/surfs/elements/spec/image.clj
+++ b/src/thlack/surfs/elements/spec/image.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.elements.spec.image
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:image})
+
+(s/def ::image_url ::strings.spec/url-string)
+
+(s/def ::alt_text ::strings.spec/string)

--- a/src/thlack/surfs/elements/spec/image.clj
+++ b/src/thlack/surfs/elements/spec/image.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.image
+(ns ^:no-doc thlack.surfs.elements.spec.image
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/multi_channels_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_channels_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.multi-channels-select
+(ns ^:no-doc thlack.surfs.elements.spec.multi-channels-select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/multi_channels_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_channels_select.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.elements.spec.multi-channels-select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:multi_channels_select})
+
+(s/def ::initial_channels (s/coll-of ::strings.spec/id :into [] :gen-max 10 :min-count 1))

--- a/src/thlack/surfs/elements/spec/multi_conversations_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_conversations_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.multi-conversations-select
+(ns ^:no-doc thlack.surfs.elements.spec.multi-conversations-select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/multi_conversations_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_conversations_select.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.elements.spec.multi-conversations-select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:multi_conversations_select})
+
+(s/def ::initial_conversations (s/coll-of ::strings.spec/id :into [] :gen-max 5 :min-count 1))

--- a/src/thlack/surfs/elements/spec/multi_external_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_external_select.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.elements.spec.multi-external-select
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::type #{:multi_external_select})

--- a/src/thlack/surfs/elements/spec/multi_external_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_external_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.multi-external-select
+(ns ^:no-doc thlack.surfs.elements.spec.multi-external-select
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::type #{:multi_external_select})

--- a/src/thlack/surfs/elements/spec/multi_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.multi-select
+(ns ^:no-doc thlack.surfs.elements.spec.multi-select
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::max_selected_items pos-int?)

--- a/src/thlack/surfs/elements/spec/multi_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_select.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.elements.spec.multi-select
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::max_selected_items pos-int?)

--- a/src/thlack/surfs/elements/spec/multi_static_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_static_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.multi-static-select
+(ns ^:no-doc thlack.surfs.elements.spec.multi-static-select
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::type #{:multi_static_select})

--- a/src/thlack/surfs/elements/spec/multi_static_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_static_select.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.elements.spec.multi-static-select
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::type #{:multi_static_select})

--- a/src/thlack/surfs/elements/spec/multi_users_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_users_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.multi-users-select
+(ns ^:no-doc thlack.surfs.elements.spec.multi-users-select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/multi_users_select.clj
+++ b/src/thlack/surfs/elements/spec/multi_users_select.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.elements.spec.multi-users-select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:multi_users_select})
+
+(s/def ::initial_users (s/coll-of ::strings.spec/id :into [] :gen-max 10 :min-count 1))

--- a/src/thlack/surfs/elements/spec/overflow.clj
+++ b/src/thlack/surfs/elements/spec/overflow.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.overflow
+(ns ^:no-doc thlack.surfs.elements.spec.overflow
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec]))

--- a/src/thlack/surfs/elements/spec/overflow.clj
+++ b/src/thlack/surfs/elements/spec/overflow.clj
@@ -1,0 +1,12 @@
+(ns thlack.surfs.elements.spec.overflow
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:overflow})
+
+(s/def ::url (s/and ::strings.spec/url-string (strings.spec/max-len 3000)))
+
+(s/def ::option (s/merge ::comp.spec/option (s/keys :opt-un [::url])))
+
+(s/def ::options (s/coll-of ::option :into [] :min-count 2 :max-count 5 :gen-max 3))

--- a/src/thlack/surfs/elements/spec/plain_text_input.clj
+++ b/src/thlack/surfs/elements/spec/plain_text_input.clj
@@ -1,0 +1,16 @@
+(ns thlack.surfs.elements.spec.plain-text-input
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(s/def ::type #{:plain_text_input})
+
+(deftext ::placeholder ::comp.spec/plain-text 150)
+
+(s/def ::initial_value ::strings.spec/string)
+
+(s/def ::multiline boolean?)
+
+(s/def ::min_length (s/int-in 1 3001))
+
+(s/def ::max_length pos-int?)

--- a/src/thlack/surfs/elements/spec/plain_text_input.clj
+++ b/src/thlack/surfs/elements/spec/plain_text_input.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.plain-text-input
+(ns ^:no-doc thlack.surfs.elements.spec.plain-text-input
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/elements/spec/radio_buttons.clj
+++ b/src/thlack/surfs/elements/spec/radio_buttons.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.radio-buttons
+(ns ^:no-doc thlack.surfs.elements.spec.radio-buttons
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]))
 

--- a/src/thlack/surfs/elements/spec/radio_buttons.clj
+++ b/src/thlack/surfs/elements/spec/radio_buttons.clj
@@ -1,0 +1,9 @@
+(ns thlack.surfs.elements.spec.radio-buttons
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]))
+
+(s/def ::type #{:radio_buttons})
+
+(s/def ::options (s/coll-of ::comp.spec/option :into [] :min-count 1 :max-count 10 :gen-max 5))
+
+(s/def ::initial_option ::comp.spec/option)

--- a/src/thlack/surfs/elements/spec/select.clj
+++ b/src/thlack/surfs/elements/spec/select.clj
@@ -1,0 +1,16 @@
+(ns thlack.surfs.elements.spec.select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :refer [deftext]]))
+
+(deftext ::placeholder ::comp.spec/plain-text 150)
+
+(s/def ::options (s/coll-of ::comp.spec/option :max-count 100 :min-count 1 :into [] :gen-max 5))
+
+(s/def ::option_groups (s/coll-of ::comp.spec/option-group :max-count 100 :min-count 1 :into [] :gen-max 5))
+
+(s/def ::initial_option ::comp.spec/option)
+
+(s/def ::initial_options ::options)
+
+(s/def ::response_url_enabled boolean?)

--- a/src/thlack/surfs/elements/spec/select.clj
+++ b/src/thlack/surfs/elements/spec/select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.select
+(ns ^:no-doc thlack.surfs.elements.spec.select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/elements/spec/static_select.clj
+++ b/src/thlack/surfs/elements/spec/static_select.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.elements.spec.static-select
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::type #{:static_select})

--- a/src/thlack/surfs/elements/spec/static_select.clj
+++ b/src/thlack/surfs/elements/spec/static_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.static-select
+(ns ^:no-doc thlack.surfs.elements.spec.static-select
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::type #{:static_select})

--- a/src/thlack/surfs/elements/spec/timepicker.clj
+++ b/src/thlack/surfs/elements/spec/timepicker.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.timepicker
+(ns ^:no-doc thlack.surfs.elements.spec.timepicker
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/elements/spec/timepicker.clj
+++ b/src/thlack/surfs/elements/spec/timepicker.clj
@@ -1,0 +1,10 @@
+(ns thlack.surfs.elements.spec.timepicker
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+
+(s/def ::type #{:timepicker})
+
+(s/def ::initial_time ::strings.spec/time-string)
+
+(deftext ::placeholder ::comp.spec/plain-text 150)

--- a/src/thlack/surfs/elements/spec/users_select.clj
+++ b/src/thlack/surfs/elements/spec/users_select.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.elements.spec.users-select
+(ns ^:no-doc thlack.surfs.elements.spec.users-select
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.strings.spec :as strings.spec]))
 

--- a/src/thlack/surfs/elements/spec/users_select.clj
+++ b/src/thlack/surfs/elements/spec/users_select.clj
@@ -1,0 +1,7 @@
+(ns thlack.surfs.elements.spec.users-select
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.strings.spec :as strings.spec]))
+
+(s/def ::type #{:users_select})
+
+(s/def ::initial_user ::strings.spec/id)

--- a/src/thlack/surfs/messages/components.clj
+++ b/src/thlack/surfs/messages/components.clj
@@ -2,8 +2,8 @@
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.props :as props]
             [thlack.surfs.validation :refer [validated]]
-            [thlack.surfs.messages.spec :as messages.spec]
-            [thlack.surfs.messages.components.spec]))
+            [thlack.surfs.messages.spec :as message]
+            [thlack.surfs.messages.components.spec :as mc.spec]))
 
 (defn message
   "Define a message. Supports the common message definition defined [here](https://api.slack.com/reference/messaging/payload).
@@ -52,18 +52,18 @@
         (cond->
          (some? text) (assoc :text text)
          (seq blocks) (assoc :blocks (props/flatten-children blocks)))
-        (validated ::messages.spec/message))))
+        (validated ::message/message))))
 
 (s/fdef message
-  :args (s/alt :text-only             (s/cat :text :message/text)
-               :props-text-only       (s/cat :props :message/props
-                                             :text :message/text)
-               :blocks-only           (s/cat :blocks :message/children)
-               :props-blocks-only     (s/cat :props :message/props
-                                             :blocks :message/children)
-               :blocks-and-text       (s/cat :text :message/text
-                                             :blocks :message/children)
-               :props-blocks-and-text (s/cat :props :message/props
-                                             :text :message/text
-                                             :blocks :message/children))
-  :ret  ::messages.spec/message)
+  :args (s/alt :text-only             (s/cat :text ::message/text)
+               :props-text-only       (s/cat :props ::mc.spec/message.props
+                                             :text ::message/text)
+               :blocks-only           (s/cat :blocks ::mc.spec/message.children)
+               :props-blocks-only     (s/cat :props ::mc.spec/message.props
+                                             :blocks ::mc.spec/message.children)
+               :blocks-and-text       (s/cat :text ::message/text
+                                             :blocks ::mc.spec/message.children)
+               :props-blocks-and-text (s/cat :props ::mc.spec/message.props
+                                             :text ::message/text
+                                             :blocks ::mc.spec/message.children))
+  :ret  ::message/message)

--- a/src/thlack/surfs/messages/components.clj
+++ b/src/thlack/surfs/messages/components.clj
@@ -45,7 +45,7 @@
      [:text \"Text two\"]]]
    ```"
   [& args]
-  (let [[props & children] (props/parse-args args)
+  (let [[props & children] (props/parse-args args mc.spec/message-props?)
         text (some #(if (string? %) % nil) children)
         blocks (filter (complement string?) children)]
     (-> props

--- a/src/thlack/surfs/messages/components/spec.clj
+++ b/src/thlack/surfs/messages/components/spec.clj
@@ -2,16 +2,16 @@
 (ns ^:no-doc thlack.surfs.messages.components.spec
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.blocks.spec :as blocks.spec]
-            [thlack.surfs.messages.spec]))
+            [thlack.surfs.messages.spec :as message]))
 
 ;;; [:message]
 
-(s/def :message/props
-  (s/keys :opt-un [:message/thread_ts :message/mrkdwn]))
+(s/def ::message.props
+  (s/keys :opt-un [::message/thread_ts ::message/mrkdwn]))
 
-(s/def :message/child (s/or :block ::blocks.spec/block :text :message/text))
+(s/def ::message.child (s/or :block ::blocks.spec/block :text ::message/text))
 
-(s/def :message/children
+(s/def ::message.children
   (s/with-gen
-    (s/* :message/child)
-    #(s/gen :message/blocks)))
+    (s/* ::message.child)
+    #(s/gen ::message/blocks)))

--- a/src/thlack/surfs/messages/components/spec.clj
+++ b/src/thlack/surfs/messages/components/spec.clj
@@ -9,6 +9,15 @@
 (s/def ::message.props
   (s/keys :opt-un [::message/thread_ts ::message/mrkdwn]))
 
+(defn message-props?
+  [props]
+  (if (map? props)
+    (-> props
+        (select-keys [:thread_ts :mrkdwn])
+        (seq)
+        (some?))
+    false))
+
 (s/def ::message.child (s/or :block ::blocks.spec/block :text ::message/text))
 
 (s/def ::message.children

--- a/src/thlack/surfs/messages/spec.clj
+++ b/src/thlack/surfs/messages/spec.clj
@@ -5,17 +5,17 @@
             [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]
             [thlack.surfs.blocks.spec :as blocks.spec]))
 
-(deftext :message/text ::strings.spec/string 40000)
+(deftext ::text ::strings.spec/string 40000)
 
-(s/def :message/blocks (s/coll-of ::blocks.spec/block :into [] :max-count 50 :min-count 1 :gen-max 3))
+(s/def ::blocks (s/coll-of ::blocks.spec/block :into [] :max-count 50 :min-count 1 :gen-max 3))
 
-(s/def :message/thread_ts ::strings.spec/string)
+(s/def ::thread_ts ::strings.spec/string)
 
-(s/def :message/mrkdwn boolean?)
+(s/def ::mrkdwn boolean?)
 
-(s/def ::message-optional-blocks (s/keys :req-un [:message/text] :opt-un [:message/blocks :message/thread_ts :message/mrkdwn]))
+(s/def ::message-optional-blocks (s/keys :req-un [::text] :opt-un [::blocks ::thread_ts ::mrkdwn]))
 
-(s/def ::message-optional-text (s/keys :req-un [:message/blocks] :opt-un [:message/text :message/thread_ts :message/mrkdwn]))
+(s/def ::message-optional-text (s/keys :req-un [::blocks] :opt-un [::text ::thread_ts ::mrkdwn]))
 
 (s/def ::message
   (s/or :optional-blocks ::message-optional-blocks :optional-text ::message-optional-text))

--- a/src/thlack/surfs/props.clj
+++ b/src/thlack/surfs/props.clj
@@ -1,6 +1,8 @@
 (ns ^:no-doc thlack.surfs.props
   (:require [clojure.spec.alpha :as s]
-            [thlack.surfs.blocks.spec]))
+            [thlack.surfs.blocks.spec]
+            [thlack.surfs.blocks.spec.section :as section]
+            [thlack.surfs.blocks.spec.input :as input]))
 
 ;;; Prop helpers
 
@@ -61,8 +63,8 @@
     #{:option-group}       (update children :option_groups conj data)
     #{:text}               (assoc children :text (detag data))
     #{:fields}             (merge children (update data :fields #(map second %)))
-    #{:accessory}          (assoc children tag (detag data :section/accessory))
-    #{:element}            (assoc children tag (detag data :input/element))
+    #{:accessory}          (assoc children tag (detag data ::section/accessory))
+    #{:element}            (assoc children tag (detag data ::input/element))
     (assoc children tag data)))
 
 (defn flatten-children

--- a/src/thlack/surfs/render.clj
+++ b/src/thlack/surfs/render.clj
@@ -12,50 +12,50 @@
 ;;; a keyword tag to a render function.
 
 (def tags
-  {:home                       views/home
-   :modal                      views/modal
-   :message                    messages/message
-   :actions                    blocks/actions
-   :context                    blocks/context
-   :divider                    blocks/divider
-   :header                     blocks/header
-   :image                      blocks/image
-   :section                    blocks/section
-   :input                      blocks/input
-   :fields                     blocks/fields
-   :button                     elements/button
-   :checkboxes                 elements/checkboxes
-   :datepicker                 elements/datepicker
-   :timepicker                 elements/timepicker
-   :img                        elements/img
-   :multi-external-select      elements/multi-external-select
-   :multi-users-select         elements/multi-users-select
-   :multi-conversations-select elements/multi-conversations-select
-   :multi-channels-select      elements/multi-channels-select
-   :multi-static-select        elements/multi-static-select
-   :static-select              elements/static-select
-   :external-select            elements/external-select
-   :users-select               elements/users-select
-   :conversations-select       elements/conversations-select
-   :channels-select            elements/channels-select
-   :overflow                   elements/overflow
-   :plain-text-input           elements/plain-text-input
-   :radio-buttons              elements/radio-buttons
-   :plain-text                 comp/plain-text
-   :label                      comp/plain-text
-   :placeholder                comp/plain-text
-   :hint                       comp/plain-text
-   :title                      comp/plain-text
-   :confirm                    comp/confirm
-   :option                     comp/option
-   :option-group               comp/option-group
-   :markdown                   comp/markdown
-   :text                       comp/text})
+  {:home                       #'views/home
+   :modal                      #'views/modal
+   :message                    #'messages/message
+   :actions                    #'blocks/actions
+   :context                    #'blocks/context
+   :divider                    #'blocks/divider
+   :header                     #'blocks/header
+   :image                      #'blocks/image
+   :section                    #'blocks/section
+   :input                      #'blocks/input
+   :fields                     #'blocks/fields
+   :button                     #'elements/button
+   :checkboxes                 #'elements/checkboxes
+   :datepicker                 #'elements/datepicker
+   :timepicker                 #'elements/timepicker
+   :img                        #'elements/img
+   :multi-external-select      #'elements/multi-external-select
+   :multi-users-select         #'elements/multi-users-select
+   :multi-conversations-select #'elements/multi-conversations-select
+   :multi-channels-select      #'elements/multi-channels-select
+   :multi-static-select        #'elements/multi-static-select
+   :static-select              #'elements/static-select
+   :external-select            #'elements/external-select
+   :users-select               #'elements/users-select
+   :conversations-select       #'elements/conversations-select
+   :channels-select            #'elements/channels-select
+   :overflow                   #'elements/overflow
+   :plain-text-input           #'elements/plain-text-input
+   :radio-buttons              #'elements/radio-buttons
+   :plain-text                 #'comp/plain-text
+   :label                      #'comp/plain-text
+   :placeholder                #'comp/plain-text
+   :hint                       #'comp/plain-text
+   :title                      #'comp/plain-text
+   :confirm                    #'comp/confirm
+   :option                     #'comp/option
+   :option-group               #'comp/option-group
+   :markdown                   #'comp/markdown
+   :text                       #'comp/text})
 
 (defn- render-tag
   [[head & args]]
   (if-let [render-fn (tags head)]
-    (apply render-fn args)
+    (apply (var-get render-fn) args)
     (apply vector head args)))
 
 (defn- expand

--- a/src/thlack/surfs/repl.clj
+++ b/src/thlack/surfs/repl.clj
@@ -1,0 +1,39 @@
+(ns thlack.surfs.repl
+  "Repl helpers for surfs. Useful for exploring component specs and
+   getting documentation."
+  (:require [thlack.surfs.repl.impl :as impl]))
+
+(defn describe
+  "Returns raw metadata about a component. Includes function metadata as well
+   as the fspec of the component's render function. describe might be considered
+   them most \"low level\" repl utility.
+   
+   Usage:
+   
+   ```clojure
+   (describe :static-select)
+   ```"
+  [tag]
+  (impl/describe tag))
+
+(defn doc
+  "Prints the full documentation of a component. This documentation includes component signatures
+   as well as usage examples.
+   
+   Usage:
+   
+   ```clojure
+   (doc :static-select)
+   ```"
+  [tag]
+  (impl/doc tag))
+
+(defn props
+  "Returns the spec for a component's props if it has them. Specs leveraging merge
+   will have their keywords fully expanded into a valid `keys` spec.
+   
+   ```clojure
+   (props :multi-external-select)
+   ```"
+  [tag]
+  (impl/props tag))

--- a/src/thlack/surfs/repl/impl.clj
+++ b/src/thlack/surfs/repl/impl.clj
@@ -1,0 +1,104 @@
+(ns ^:no-doc thlack.surfs.repl.impl
+  (:require [clojure.spec.alpha :as s]
+            [clojure.string :as string]
+            [thlack.surfs.render :as render]))
+
+(defn- get-var
+  [tag]
+  (render/tags tag))
+
+(defn- get-meta
+  [tag]
+  (some-> tag
+          (get-var)
+          (meta)
+          (select-keys [:doc :name])))
+
+(defn- get-spec
+  [tag]
+  (some->> tag
+           (get-var)
+           (s/get-spec)
+           (s/describe)
+           (next)
+           (apply hash-map)))
+
+(defn- with-spec
+  [tag description]
+  (assoc description :spec (get-spec tag)))
+
+(defn describe
+  [tag]
+  (->> tag
+       (get-meta)
+       (with-spec tag)
+       (merge {:tag tag})))
+
+(defn- get-args
+  [{{:keys [args]} :spec}]
+  args)
+
+(defn- get-cats'
+  [args]
+  (let [head (first args)]
+    (if (= 'alt head)
+      (vals (apply hash-map (rest args)))
+      (list args))))
+
+(defn- get-cats
+  [args]
+  (->> args
+       (get-cats')
+       (map (fn [c]
+              (map (fn [x]
+                     (if (seq? x)
+                       (second x)
+                       x)) c)))))
+
+(defn- signature-string
+  "Get an arglist based on a function spec."
+  [{:keys [tag] :as description}]
+  (->> (get-args description)
+       (get-cats)
+       (map rest)
+       (map #(map symbol %))
+       (map #(take-nth 2 %))
+       (map vec)
+       (map #(into [tag] %))
+       (pr-str)))
+
+(defn- doc-string
+  "Get the doc string for a component description"
+  [description]
+  (some-> description
+          (:doc)
+          (string/replace #"^" "   ")
+          (string/split-lines)
+          (#(string/join (System/lineSeparator) %))))
+
+(defn doc
+  [tag]
+  (let [description (describe tag)]
+    (->> description
+         (doc-string)
+         (str (signature-string description) (System/lineSeparator))
+         (println))))
+
+(defn- expand-prop
+  [prop]
+  (if (qualified-keyword? prop)
+    (s/describe prop)
+    prop))
+
+(defn props
+  [tag]
+  (some->> tag
+           (describe)
+           (get-args)
+           (get-cats)
+           (map #(apply hash-map (rest %)))
+           (filter #(contains? % :props))
+           (first)
+           :props
+           (s/describe)
+           (map expand-prop)))

--- a/src/thlack/surfs/views/components.clj
+++ b/src/thlack/surfs/views/components.clj
@@ -3,7 +3,7 @@
             [thlack.surfs.props :as props]
             [thlack.surfs.validation :refer [validated]]
             [thlack.surfs.views.spec :as views.spec]
-            [thlack.surfs.views.components.spec]))
+            [thlack.surfs.views.components.spec :as vc.spec]))
 
 (defn- with-private-metadata
   "Supports private_metadata as Clojure data structures. If a private_metadata
@@ -39,8 +39,8 @@
         (validated ::views.spec/home))))
 
 (s/fdef home
-  :args (s/alt :props-and-blocks (s/cat :props :view/props :children :view/children)
-               :blocks (s/cat :children :view/children))
+  :args (s/alt :props-and-blocks (s/cat :props ::vc.spec/view.props :children ::vc.spec/view.children)
+               :blocks (s/cat :children ::vc.spec/view.children))
   :ret ::views.spec/home)
 
 (defn modal
@@ -64,5 +64,5 @@
       (validated ::views.spec/modal)))
 
 (s/fdef modal
-  :args (s/cat :props :modal/props :children :view/children)
+  :args (s/cat :props ::vc.spec/modal.props :children ::vc.spec/view.children)
   :ret ::views.spec/modal)

--- a/src/thlack/surfs/views/components/spec.clj
+++ b/src/thlack/surfs/views/components/spec.clj
@@ -3,7 +3,9 @@
             [clojure.spec.gen.alpha :as gen]
             [thlack.surfs.blocks.spec :as blocks.spec]
             [thlack.surfs.props.spec :as props.spec]
-            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]))
+            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]
+            [thlack.surfs.views.spec :as view]
+            [thlack.surfs.views.spec.modal :as modal]))
 
 ;;; Override private_metadata spec so it accomodates any value. All
 ;;; private_metadata will be passed through (pr-str) so Clojure data structures
@@ -14,23 +16,28 @@
     any?
     #(gen/return {:meta? true :data? true})))
 
-(s/def :view/props (s/keys :opt-un [::private_metadata :view/callback_id :view/external_id]))
+(s/def ::view.props (s/keys :opt-un [::private_metadata ::view/callback_id ::view/external_id]))
 
-(s/def :view/child (s/or :block ::blocks.spec/block))
+(s/def ::view.child (s/or :block ::blocks.spec/block))
 
-(s/def :view/children
+(s/def ::view.children
   (s/with-gen
-    (s/+ :view/child)
-    #(s/gen :view/blocks)))
+    (s/+ ::view.child)
+    #(s/gen ::view/blocks)))
 
 ;;; [:modal]
 
-(deftext :modal-props/string ::strings.spec/string 24)
+(deftext ::modal-props.string ::strings.spec/string 24)
 
-(s/def :modal-props/title :modal-props/string)
+(s/def :thlack.surfs.views.components.spec.modal-props/title ::modal-props.string)
 
-(s/def :modal-props/close :modal-props/string)
+(s/def :thlack.surfs.views.components.spec.modal-props/close ::modal-props.string)
 
-(s/def :modal-props/submit :modal-props/string)
+(s/def :thlack.surfs.views.components.spec.modal-props/submit ::modal-props.string)
 
-(s/def :modal/props (s/merge :view/props (s/keys :req-un [:modal-props/title] :opt-un [:modal-props/close :modal-props/submit :modal/clear_on_close :modal/notify_on_close ::props.spec/disable_emoji_for])))
+(s/def ::modal.props (s/merge ::view.props (s/keys :req-un [:thlack.surfs.views.components.spec.modal-props/title]
+                                                   :opt-un [:thlack.surfs.views.components.spec.modal-props/close
+                                                            :thlack.surfs.views.components.spec.modal-props/submit
+                                                            ::modal/clear_on_close
+                                                            ::modal/notify_on_close
+                                                            ::props.spec/disable_emoji_for])))

--- a/src/thlack/surfs/views/spec.clj
+++ b/src/thlack/surfs/views/spec.clj
@@ -1,35 +1,22 @@
 (ns ^:no-doc thlack.surfs.views.spec
   (:require [clojure.spec.alpha :as s]
-            [thlack.surfs.strings.spec :as strings.spec :refer [deftext]]
-            [thlack.surfs.composition.spec :as comp.spec]
-            [thlack.surfs.blocks.spec :as blocks.spec]))
+            [thlack.surfs.strings.spec :as strings.spec]
+            [thlack.surfs.blocks.spec :as blocks.spec]
+            [thlack.surfs.views.spec.modal :as modal]
+            [thlack.surfs.views.spec.home :as home]))
 
-(s/def :modal/type #{:modal})
+(s/def ::blocks (s/coll-of ::blocks.spec/block :into [] :max-count 100 :min-count 1 :gen-max 3))
 
-(s/def :home/type #{:home})
+(s/def ::private_metadata (strings.spec/with-max-gen
+                            ::strings.spec/string
+                            3000))
 
-(deftext :modal/title ::comp.spec/plain-text 24)
+(s/def ::callback_id (strings.spec/with-max-gen
+                       ::strings.spec/string
+                       255))
 
-(s/def :view/blocks (s/coll-of ::blocks.spec/block :into [] :max-count 100 :min-count 1 :gen-max 3))
+(s/def ::external_id ::strings.spec/string)
 
-(deftext :modal/close ::comp.spec/plain-text 24)
+(s/def ::home (s/keys :req-un [::home/type ::blocks] :opt-un [::private_metadata ::callback_id ::external_id]))
 
-(deftext :modal/submit ::comp.spec/plain-text 24)
-
-(s/def :view/private_metadata (strings.spec/with-max-gen
-                                ::strings.spec/string
-                                3000))
-
-(s/def :view/callback_id (strings.spec/with-max-gen
-                           ::strings.spec/string
-                           255))
-
-(s/def :modal/clear_on_close boolean?)
-
-(s/def :modal/notify_on_close boolean?)
-
-(s/def :view/external_id ::strings.spec/string)
-
-(s/def ::home (s/keys :req-un [:home/type :view/blocks] :opt-un [:view/private_metadata :view/callback_id :view/external_id]))
-
-(s/def ::modal (s/keys :req-un [:modal/type :view/blocks :modal/title] :opt-un [:modal/close :modal/submit :view/private_metadata :view/callback_id :modal/clear_on_close :modal/notify_on_close :view/external_id]))
+(s/def ::modal (s/keys :req-un [::modal/type ::blocks ::modal/title] :opt-un [::modal/close ::modal/submit ::private_metadata ::callback_id ::modal/clear_on_close ::modal/notify_on_close ::external_id]))

--- a/src/thlack/surfs/views/spec/home.clj
+++ b/src/thlack/surfs/views/spec/home.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.views.spec.home
+(ns ^:no-doc thlack.surfs.views.spec.home
   (:require [clojure.spec.alpha :as s]))
 
 (s/def ::type #{:home})

--- a/src/thlack/surfs/views/spec/home.clj
+++ b/src/thlack/surfs/views/spec/home.clj
@@ -1,0 +1,4 @@
+(ns thlack.surfs.views.spec.home
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::type #{:home})

--- a/src/thlack/surfs/views/spec/modal.clj
+++ b/src/thlack/surfs/views/spec/modal.clj
@@ -1,4 +1,4 @@
-(ns thlack.surfs.views.spec.modal
+(ns ^:no-doc thlack.surfs.views.spec.modal
   (:require [clojure.spec.alpha :as s]
             [thlack.surfs.composition.spec :as comp.spec]
             [thlack.surfs.strings.spec :refer [deftext]]))

--- a/src/thlack/surfs/views/spec/modal.clj
+++ b/src/thlack/surfs/views/spec/modal.clj
@@ -1,0 +1,16 @@
+(ns thlack.surfs.views.spec.modal
+  (:require [clojure.spec.alpha :as s]
+            [thlack.surfs.composition.spec :as comp.spec]
+            [thlack.surfs.strings.spec :refer [deftext]]))
+
+(s/def ::type #{:modal})
+
+(deftext ::title ::comp.spec/plain-text 24)
+
+(deftext ::close ::comp.spec/plain-text 24)
+
+(deftext ::submit ::comp.spec/plain-text 24)
+
+(s/def ::clear_on_close boolean?)
+
+(s/def ::notify_on_close boolean?)

--- a/test/thlack/surfs/messages/components_test.clj
+++ b/test/thlack/surfs/messages/components_test.clj
@@ -2,4 +2,4 @@
   (:require [thlack.surfs.messages.components :as co]
             [thlack.surfs.test-utils :refer [defcheck]]))
 
-(defcheck message `co/message 5)
+(defcheck message `co/message 18)

--- a/test/thlack/surfs/render_test.clj
+++ b/test/thlack/surfs/render_test.clj
@@ -6,16 +6,18 @@
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.properties :as prop]
             [thlack.surfs.render :as surfs.render]
-            [thlack.surfs.blocks.components.spec]
+            [thlack.surfs.blocks.components.spec :as bc.spec]
             [thlack.surfs.blocks.spec :as blocks.spec]
-            [thlack.surfs.elements.components.spec]
+            [thlack.surfs.elements.components.spec :as ec.spec]
             [thlack.surfs.elements.spec :as elements.spec]
-            [thlack.surfs.composition.components.spec]
             [thlack.surfs.composition.spec :as comp.spec]
-            [thlack.surfs.messages.components.spec]
+            [thlack.surfs.composition.spec.confirm :as confirm]
+            [thlack.surfs.composition.spec.option :as option]
+            [thlack.surfs.composition.components.spec :as cc.spec]
+            [thlack.surfs.messages.components.spec :as mc.spec]
             [thlack.surfs.messages.spec :as messages.spec]
             [thlack.surfs.test-utils :refer [render]]
-            [thlack.surfs.views.components.spec]
+            [thlack.surfs.views.components.spec :as vc.spec]
             [thlack.surfs.views.spec :as views.spec]))
 
 (def iterations 10)
@@ -29,16 +31,16 @@
 
 (defspec confirm
   iterations
-  (prop/for-all [props (s/gen :confirm/props)]
-                (let [text (gen/generate (s/gen :confirm/text))]
+  (prop/for-all [props (s/gen ::cc.spec/confirm.props)]
+                (let [text (gen/generate (s/gen ::confirm/text))]
                   (render ::comp.spec/confirm
                           [:confirm props
                            [:text text]]))))
 
 (defspec option
   iterations
-  (prop/for-all [props (s/gen :option/props)]
-                (let [text (gen/generate (s/gen :option/text))]
+  (prop/for-all [props (s/gen ::cc.spec/option.props)]
+                (let [text (gen/generate (s/gen ::option/text))]
                   (render ::comp.spec/option [:option props text]))))
 
 (defn with-description
@@ -97,7 +99,7 @@
 
 (defspec checkboxes
   iterations
-  (prop/for-all [props   (s/gen :checkboxes/props)
+  (prop/for-all [props   (s/gen ::ec.spec/checkboxes.props)
                  element (s/gen ::elements.spec/checkboxes)]
                 (let [{options :options
                        confirm :confirm} element]
@@ -108,7 +110,7 @@
 
 (defspec datepicker
   iterations
-  (prop/for-all [props (s/gen :datepicker/props)
+  (prop/for-all [props (s/gen ::ec.spec/datepicker.props)
                  element (s/gen ::elements.spec/datepicker)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -120,7 +122,7 @@
 
 (defspec timepicker
   iterations
-  (prop/for-all [props (s/gen :timepicker/props)
+  (prop/for-all [props (s/gen ::ec.spec/timepicker.props)
                  element (s/gen ::elements.spec/timepicker)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -137,7 +139,7 @@
 
 (defspec multi-static-select
   iterations
-  (prop/for-all [props (s/gen :multi-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/multi-select.props)
                  element (s/gen ::elements.spec/multi-static-select)]
                 (let [{placeholder   :placeholder
                        options       :options
@@ -152,7 +154,7 @@
 
 (defspec multi-external-select
   iterations
-  (prop/for-all [props (s/gen :multi-external-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/multi-external-select.props)
                  element (s/gen ::elements.spec/multi-external-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -163,7 +165,7 @@
 
 (defspec multi-users-select
   iterations
-  (prop/for-all [props (s/gen :multi-users-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/multi-users-select.props)
                  element (s/gen ::elements.spec/multi-users-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -174,7 +176,7 @@
 
 (defspec multi-conversations-select
   iterations
-  (prop/for-all [props (s/gen :multi-conversations-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/multi-conversations-select.props)
                  element (s/gen ::elements.spec/multi-conversations-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -185,7 +187,7 @@
 
 (defspec multi-channels-select
   iterations
-  (prop/for-all [props (s/gen :multi-channels-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/multi-channels-select.props)
                  element (s/gen ::elements.spec/multi-channels-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -196,7 +198,7 @@
 
 (defspec static-select
   iterations
-  (prop/for-all [props (s/gen :static-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/static-select.props)
                  element (s/gen ::elements.spec/static-select)]
                 (let [{placeholder   :placeholder
                        options       :options
@@ -211,7 +213,7 @@
 
 (defspec external-select
   iterations
-  (prop/for-all [props (s/gen :external-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/external-select.props)
                  element (s/gen ::elements.spec/external-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -222,7 +224,7 @@
 
 (defspec users-select
   iterations
-  (prop/for-all [props (s/gen :users-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/users-select.props)
                  element (s/gen ::elements.spec/users-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -233,7 +235,7 @@
 
 (defspec conversations-select
   iterations
-  (prop/for-all [props (s/gen :conversations-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/conversations-select.props)
                  element (s/gen ::elements.spec/conversations-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -244,7 +246,7 @@
 
 (defspec channels-select
   iterations
-  (prop/for-all [props (s/gen :channels-select/props)
+  (prop/for-all [props (s/gen ::ec.spec/channels-select.props)
                  element (s/gen ::elements.spec/channels-select)]
                 (let [{placeholder :placeholder
                        confirm     :confirm} element]
@@ -263,7 +265,7 @@
 
 (defspec plain-text-input
   iterations
-  (prop/for-all [props (s/gen :plain-text-input/props)
+  (prop/for-all [props (s/gen ::ec.spec/plain-text-input.props)
                  element (s/gen ::elements.spec/plain-text-input)]
                 (render ::elements.spec/plain-text-input
                         [:plain-text-input props
@@ -272,7 +274,7 @@
 
 (defspec radio-buttons
   iterations
-  (prop/for-all [props (s/gen :radio-buttons/props)
+  (prop/for-all [props (s/gen ::ec.spec/radio-buttons.props)
                  element (s/gen ::elements.spec/radio-buttons)]
                 (let [{options :options
                        confirm :confirm} element]
@@ -283,7 +285,7 @@
 
 (defspec actions
   iterations
-  (prop/for-all [props (s/gen :block/props)
+  (prop/for-all [props (s/gen ::bc.spec/block.props)
                  block (s/gen ::blocks.spec/actions)]
                 (render ::blocks.spec/actions
                         (apply vector :actions
@@ -297,7 +299,7 @@
 
 (defspec section
   iterations
-  (prop/for-all [props (s/gen :block/props)
+  (prop/for-all [props (s/gen ::bc.spec/block.props)
                  element (s/gen ::blocks.spec/section)]
                 (let [{text   :text
                        fields :fields
@@ -314,7 +316,7 @@
 (defspec context
   iterations
   (prop/for-all [block (s/gen ::blocks.spec/context)
-                 props (s/gen :block/props)]
+                 props (s/gen ::bc.spec/block.props)]
                 (render ::blocks.spec/context
                         [:context props
                          (map
@@ -335,7 +337,7 @@
 (defspec header
   iterations
   (prop/for-all [block (s/gen ::blocks.spec/header)
-                 props (s/gen :block/props)]
+                 props (s/gen ::bc.spec/block.props)]
                 (render ::blocks.spec/header
                         [:header props
                          [:text (:text block)]])))
@@ -343,7 +345,7 @@
 (defspec image
   iterations
   (prop/for-all [element (s/gen ::blocks.spec/image)
-                 props (s/gen :image/props)]
+                 props (s/gen ::bc.spec/image.props)]
                 (render ::blocks.spec/image
                         [:image props
                          (when (:title element)
@@ -352,7 +354,7 @@
 (defspec input
   iterations
   (prop/for-all [elem (s/gen ::blocks.spec/input)
-                 props (s/gen :input/props)]
+                 props (s/gen ::bc.spec/input.props)]
                 (let [{hint    :hint
                        label   :label
                        element :element} elem]
@@ -369,9 +371,9 @@
 
 (defspec message
   5
-  (prop/for-all [props (s/gen :message/props)
-                 text (s/gen :message/text)
-                 blocks (s/gen :message/children)]
+  (prop/for-all [props (s/gen ::mc.spec/message.props)
+                 text (s/gen ::messages.spec/text)
+                 blocks (s/gen ::mc.spec/message.children)]
                 (render ::messages.spec/message
                         (cond
                           (and text blocks) (apply vector :message props text blocks)
@@ -382,14 +384,14 @@
 
 (defspec home
   1
-  (prop/for-all [props (s/gen :view/props)
-                 blocks (s/gen :view/children)]
+  (prop/for-all [props (s/gen ::vc.spec/view.props)
+                 blocks (s/gen ::vc.spec/view.children)]
                 (render ::views.spec/home
                         (apply vector :home props blocks))))
 
 (defspec modal
   1
-  (prop/for-all [props (s/gen :modal/props)
-                 blocks (s/gen :view/children)]
+  (prop/for-all [props (s/gen ::vc.spec/modal.props)
+                 blocks (s/gen ::vc.spec/view.children)]
                 (render ::views.spec/modal
                         (apply vector :modal props blocks))))


### PR DESCRIPTION
Properly namespaces all keys for specs.

Todo:
- [x] Add `^:no-doc` meta to new spec namespaces
- [x] Update prop docs?
- [x] Add built-in `(surfs/describe)` for exploring components